### PR TITLE
🐛 add `utf-8` encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="tiddl",
     version="1.2.0",
     description="TIDDL (Tidal Downloader) is a Python CLI application that allows downloading Tidal tracks.",
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     readme="README.md",
     author="oskvr37",


### PR DESCRIPTION
Running `pip install -U git+https://github.com/oskvr37/tiddl.git` failed with error.
After fix `pip install -U git+https://github.com/oskvr37/tiddl.git@fix/pip-git-installation` installation is fine.
Fixes #9 