### PR TITLE
Fix release_date parsing

### DIFF
--- a/tiddl/utils.py
+++ b/tiddl/utils.py
@@ -77,7 +77,7 @@ def formatFilename(template: str, track: Track, playlist=""):
     artists = [artist["name"].strip() for artist in track["artists"]]
 
     release_date = datetime.strptime(
-        track["streamStartDate"], "%Y-%m-%dT00:00:00.000+0000"
+        track["streamStartDate"], "%Y-%m-%dT%H:%M:%S.000+0000"
     )
 
     formatted_track: FormattedTrack = {


### PR DESCRIPTION
For this song:
```
{'id': 365301593, 'title': 'can u see me in the dark?', 'duration': 239, 'replayGain': -9.04, 'peak': 0.982766, 'allowStreaming': True, 'streamReady': True, 'adSupportedStreamReady': True, 'djReady': True, 'stemReady': False, 'streamStartDate': '2024-06-06T11:00:00.000+0000', 'premiumStreamingOnly': False, 'trackNumber': 1, 'volumeNumber': 1, 'version': None, 'popularity': 53, 'copyright': '℗ 2024 Atlantic Recording Corporation', 'bpm': 123, 'description': None, 'url': 'http://www.tidal.com/track/365301593', 'isrc': 'USAT22403780', 'editable': False, 'explicit': False, 'audioQuality': 'LOSSLESS', 'audioModes': ['STEREO'], 'mediaMetadata': {'tags': ['LOSSLESS', 'HIRES_LOSSLESS']}, 'artist': {'id': 16168, 'name': 'Halestorm', 'type': 'MAIN', 'picture': '300a1a9e-f2e3-4ebc-9d90-eaa28de50cc9'}, 'artists': [{'id': 16168, 'name': 'Halestorm', 'type': 'MAIN', 'picture': '300a1a9e-f2e3-4ebc-9d90-eaa28de50cc9'}, {'id': 6332461, 'name': 'I Prevail', 'type': 'MAIN', 'picture': '62beef0b-0141-45c9-be85-8df72d2dd5f4'}], 'album': {'id': 365301592, 'title': 'can u see me in the dark?', 'cover': 'c09357ea-5923-48da-87ff-417535b30633', 'vibrantColor': '#f28a83', 'videoCover': None, 'releaseDate': '2024-06-06'}, 'mixes': {'TRACK_MIX': '0019e70621f79c7826efcf885cfe69'}, 'dateAdded': '2024-11-14T14:04:04.941+0000', 'index': 100000, 'itemUuid': 'fcd12574-d497-49b1-a160-232eae7b25c9', 'playlistNumber': 1}
```

I was getting the error:
```
  File "/usr/lib/python3.12/_strptime.py", line 333, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2024-06-06T11:00:00.000+0000' does not match format '%Y-%m-%dT00:00:00.000+0000'
```

The original date string assumed the dates from Tidal would not have a time attached to them, but this song does... So I've updated the string to reflect that possibility.