### PR TITLE
Handle errors when a track is blocked/unavailable

### DIFF
--- a/tiddl/__init__.py
+++ b/tiddl/__init__.py
@@ -140,6 +140,13 @@ def main():
         playlist="",
         cover_data=b"",
     ) -> tuple[str, str]:
+        if "status" in track and track["status"] == 404:
+            logger.warning(f"Error downloading track: {track['userMessage']}")
+            return "", ""
+        elif "allowStreaming" in track and track["allowStreaming"] is False:
+            logger.warning(f"Track \'{track['title']}\' ({track['id']}) is not available")
+            return "", ""
+
         file_dir, file_name = formatFilename(file_template, track, playlist)
 
         file_path = f"{download_path}/{file_dir}/{file_name}"
@@ -218,6 +225,9 @@ def main():
                 sleep=True,
                 cover_data=album_cover.content,
             )
+
+            if len(file_dir) == 0 and len(file_name) == 0:
+                continue
 
             if SAVE_COVER:
                 album_cover.save(f"{download_path}/{file_dir}")
@@ -310,6 +320,9 @@ def main():
                         sleep=True,
                         playlist=playlist["title"],
                     )
+
+                    if len(file_dir) == 0 and len(file_name) == 0:
+                        continue
 
                     if SAVE_COVER:
                         playlist_cover.save(f"{download_path}/{file_dir}")


### PR DESCRIPTION
### Problem
When downloading a playlist, there were some tracks that are grayed out where I am not able to stream it. If tiddl tries to download this, it has an exception and exits

### Changes
When a track is requested but unavailable for the user, it can have a status field of 404 with no track data (other than ID), or it will have track data but have an `allowStreaming` field set to false. The former happens when requesting a single track, and the latter happens when downloading a playlist. The changes log a warning that the track is unavailable and skips to the next one.


I tested this with a single available track, a single unavailable track, and a playlist that had some unavailable tracks in it.