### PR TITLE
Added track version to title

### DIFF
--- a/tiddl/metadata.py
+++ b/tiddl/metadata.py
@@ -38,8 +38,8 @@ def addMetadata(
             picture.mime = "image/jpeg"
             metadata.add_picture(picture)
 
-        metadata["TITLE"] = track.title + (track.version if track.version else "")
-        metadata["WORK"] = track.title + (track.version if track.version else "")
+        metadata["TITLE"] = track.title + (" ({})".format(track.version) if track.version else "")
+        metadata["WORK"] = track.title + (" ({})".format(track.version) if track.version else "")
         metadata["TRACKNUMBER"] = str(track.trackNumber)
         metadata["DISCNUMBER"] = str(track.volumeNumber)
 

--- a/tiddl/metadata.py
+++ b/tiddl/metadata.py
@@ -38,8 +38,8 @@ def addMetadata(
             picture.mime = "image/jpeg"
             metadata.add_picture(picture)
 
-        metadata["TITLE"] = track.title
-        metadata["WORK"] = track.title
+        metadata["TITLE"] = track.title + (track.version if track.version else "")
+        metadata["WORK"] = track.title + (track.version if track.version else "")
         metadata["TRACKNUMBER"] = str(track.trackNumber)
         metadata["DISCNUMBER"] = str(track.volumeNumber)
 

--- a/tiddl/utils.py
+++ b/tiddl/utils.py
@@ -90,7 +90,7 @@ def formatTrack(
         "playlist_number": playlist_index or 0,
     }
 
-    formatted_track = template.format(**track_dict)
+    formatted_track = template.format(**track_dict).strip()
 
     disallowed_chars = r'[\\:"*?<>|]+'
     invalid_chars = re.findall(disallowed_chars, formatted_track)
@@ -152,7 +152,7 @@ def formatResource(
     elif isinstance(resource, Video):
         resource_dict.update({"quality": resource.quality})
 
-    formatted_template = template.format(**resource_dict)
+    formatted_template = template.format(**resource_dict).strip()
 
     disallowed_chars = r'[\\:"*?<>|]+'
     invalid_chars = re.findall(disallowed_chars, formatted_template)


### PR DESCRIPTION
Hello,

To add some context i was downloading [this album of Alestorm](https://listen.tidal.com/album/134050661) and I was struggling a bit to differenciate properly tracks from the first and second disc

I create this pull request to fix two things when you used tracks that can have the same name but a different "version" and to handle them in a better way that without the fix and to avoid trailing space before the extensions when using a template like that because the version is not set 

> {album_artist}/{album}/Disc {disc} - {number:02d}. {title} {version}


And as a second features added is to put the version of the track in the title metadata in the file song

If I need to change something, I'm totaly open to the discussion

PS: Sorry english is not my native langage ^^'