### PR TITLE
🐛 Fixed video download flag

### DIFF
--- a/tiddl/cli/download/__init__.py
+++ b/tiddl/cli/download/__init__.py
@@ -267,14 +267,19 @@ def DownloadCommand(
         path = Path(PATH) if PATH else ctx.obj.config.download.path
         path /= f"{filename}.*"
 
-        if not DO_NOT_SKIP:  # check if item is already downloaded
+        # Respect DOWNLOAD_VIDEO = FALSE over DO_NOT_SKIP (as it's for the file exists check)
+        if isinstance(item, Video) and not DOWNLOAD_VIDEO: 
+            logging.warning(f"Video '{item.title}' skipped as DOWNLOAD_VIDEO is false")
+            return
+        
+        if not DO_NOT_SKIP:  # check if item is already downloaded (unless DO_NOT_SKIP is set, then override anything)
             if isinstance(item, Track):
                 if trackExists(item.audioQuality, DOWNLOAD_QUALITY, path):
-                    logging.warning(f"Track '{item.title}' skipped")
+                    logging.warning(f"Track '{item.title}' skipped - exists")
                     return
             elif isinstance(item, Video):
-                if path.with_suffix(".mp4").exists() or not DOWNLOAD_VIDEO:
-                    logging.warning(f"Video '{item.title}' skipped")
+                if path.with_suffix(".mp4").exists():
+                    logging.warning(f"Video '{item.title}' skipped - exists")
                     return
 
         pool.submit(

--- a/tiddl/cli/download/__init__.py
+++ b/tiddl/cli/download/__init__.py
@@ -89,7 +89,7 @@ from typing import List, Union
 )
 @click.option(
     "--video",
-    "-v",
+    "-V",
     "DOWNLOAD_VIDEO",
     is_flag=True,
     help="Enable downloading videos",


### PR DESCRIPTION
1. Moved DOWNLOAD_VIDEO check outside of DO_NOT_SKIP (applies FIRST)
2. Cleaned up outputs (added "as DOWNLOAD_VIDEO is false" and " - exists" to relevant outputs
3. Cleaned up notes to clarify DO_NOT_SKIP is intended logic for redownloading duplicate files; not for overriding other flags

This is more in line with the description of the DO_NOT_SKIP flag and what users will expect; they won't expect it to randomly override another specifically set flag.