### PR TITLE
FFmpeg async fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "requests-cache>=1.2.1",
   "click>=8.1.7",
   "mutagen>=1.47.0",
-  "python-ffmpeg>=2.0.0",
+  "ffmpeg-asyncio>=0.0.31"
   "m3u8>=6.0.0",
   "rich>=13.9.4"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "requests-cache>=1.2.1",
   "click>=8.1.7",
   "mutagen>=1.47.0",
-  "ffmpeg-asyncio>=0.0.31"
+  "ffmpeg-asyncio>=0.0.31",
   "m3u8>=6.0.0",
   "rich>=13.9.4"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "requests-cache>=1.2.1",
   "click>=8.1.7",
   "mutagen>=1.47.0",
-  "ffmpeg-asyncio>=0.0.31",
+  "ffmpeg-asyncio>=0.1.3",
   "m3u8>=6.0.0",
   "rich>=13.9.4"
 ]

--- a/tiddl/cli/download/__init__.py
+++ b/tiddl/cli/download/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import click
-
+import asyncio
 from time import perf_counter
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -209,13 +209,13 @@ def DownloadCommand(
 
         if isinstance(item, Track):
             if track_stream.audioQuality == "HI_RES_LOSSLESS":
-                path = convertFileExtension(
+                path =  asyncio.run(convertFileExtension(
                     source_file=path,
                     extension=".flac",
                     remove_source=True,
                     is_video=False,
                     copy_audio=True,  # extract flac from m4a container
-                )
+                ))
 
             if not cover_data and item.album.cover:
                 cover_data = Cover(item.album.cover).content
@@ -231,13 +231,13 @@ def DownloadCommand(
                 logging.error(f"Can not add metadata to: {path}, {e}")
 
         elif isinstance(item, Video):
-            path = convertFileExtension(
+            path =  asyncio.run(convertFileExtension(
                 source_file=path,
                 extension=".mp4",
                 remove_source=True,
                 is_video=True,
                 copy_audio=True,
-            )
+            ))
 
             try:
                 addVideoMetadata(path, item)


### PR DESCRIPTION
**Issue:** 
It appears the issue I was having with weird metadata and duplicate m4a files was to do with threading; the threading wasn't waiting for convertFileExtension. _This means random things happen such as ffmpeg still running and a flac file appearing, but the metadata going on the m4a, the m4a not being deleted, etc etc._

**Solution:**
1. Update **convertFileExtension** to be async via ffmpeg-asyncio
2. Updated **cli/download/__init__.py** to call asyncio.run()
_Ensuring it doesn't continue until **path** is available. before it proceeds_
3. Updated **pyproject.toml** dependencies to ffmpeg-asyncio

Requires **ffmpeg installed locally**, though I believe this is always the case. 

_It appears previously the issue I was having was the thread was continuing without waiting for a 'path' return from the fileConversion ffmpeg function, resulting in a mix of flac and m4a with mixed metadata. This method it no longer clogs my screen with stalled ffmpeg threads and outputs all flac files, converting any lossless m4a to flac_