### PR TITLE
Docker ghcr.io Workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Push Docker Image to ghcr.io
+
+# Run when release is published
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # Allow for manual push so I can test it
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # Minimum required permissions
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Checkout code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Login to ghcr (automatically uses workflow actor and secret)
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pushes to both :latest and :<versionTag>
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/tiddl:${{ github.event.release.tag_name }}
+            ghcr.io/${{ github.repository_owner }}/tiddl:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:alpine
+WORKDIR /root
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pip pip install  .
+RUN rm -rf *
+RUN apk add ffmpeg

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Commands:
   url     Get Tidal URL.
 ```
 ## Dockerised Version (no Python required)
+
 Based on python:alpine, slim build
 **Docker run example (quickest / easiest)**
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Commands:
   search  Search on Tidal.
   url     Get Tidal URL.
 ```
+## Dockerised Version (no Python required)
+Based on python:alpine, slim build
+**Docker run example (quickest / easiest)**
+```
+docker run -rm -v /downloads/dir:/root/Music/Tiddl/ -v ./config/tiddl/:/root/ >
+```
+
+**docker-compose.yml example (not required, though allows for advanced configs)**
+```
+services:
+  tiddl:
+    container_name: tiddl
+    image: <ghcr.ioURL>:latest
+    volumes:
+      - /downloads/dir:/root/Music/Tiddl/ #default dir
+      - ./config/tiddl/:/root/ # Default location of config file 
+    command: tail -f /dev/null # Keep it running in background
+```
+**Access the container:**
+```
+docker exec -it tiddl sh
+```
+
+_all other instructions match python version_
 
 # Basic usage
 


### PR DESCRIPTION
1. Added Dockerfile
2. Added Docker instructions to README.md 
_(basic instructions just for those who use docker and not python, no need to duplicate things)_
3. Added docker.yml workflow 
_Builds and pushes docker image to ghcr linked to repository when a new package is released_
_Clones version number and pushes to tiddl:<releaseTag> and tiddl:latest_
_Uses all default Github workflow stuff - no configuring required, it works via GITHUB_TOKEN_

- Auto builds and pushes a docker image to ghcr.io
- Image based on python:alpine official docker image
_(slim ~10MB image with Python preinstalled, ends up <70MB compressed when pushed, and 48MB of that is ffmpeg)_
- Auto pushes to ghcr when a new release is published, cloning the version number 

