### PR TITLE
Added actual ghcr.io URL for docker commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,20 @@
+# --- Optimised Layer Caching --- #
+# Layer 1 (ffmpeg) will never regenerate
+# Layer 2 (pip install) will regenerate if pyproject.toml is changed
+# Layer 3 (build & install tiddl), rengerates on any code change
+
 FROM python:alpine
 WORKDIR /root
+
+# -- Layer 1 - ffmpeg install (it'll stay cached as a layer always) --
+RUN apk add --no-cache ffmpeg
+
+# -- Layer 2 - pip install depenencies (remains cached unless pyproject.toml changes) --
+# Exports 'depenencies' from pyproject.toml formatted to requirements.txt format, pipelined to pip install
+COPY pyproject.toml .
+RUN python -c "import tomllib; f=open('pyproject.toml','rb'); print('\n'.join(tomllib.load(f)['project']['dependencies']))" | xargs pip install 
+
+# -- Layer 3 - Uncached layer (regenerates anytime a new build is released) --
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/pip pip install  .
+RUN pip install --no-deps .
 RUN rm -rf *
-RUN apk add ffmpeg

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Commands:
 Based on python:alpine, slim build
 **Docker run example (quickest / easiest)**
 ```
-docker run -rm -v /downloads/dir:/root/Music/Tiddl/ -v ./config/tiddl/:/root/ >
+docker run -rm -v /downloads/dir:/root/Music/Tiddl/ -v ./config/tiddl/:/root/ ghcr.io/oskvr37/tiddl:latest
 ```
 
 **docker-compose.yml example (not required, though allows for advanced configs)**
@@ -58,7 +58,7 @@ docker run -rm -v /downloads/dir:/root/Music/Tiddl/ -v ./config/tiddl/:/root/ >
 services:
   tiddl:
     container_name: tiddl
-    image: <ghcr.ioURL>:latest
+    image: ghcr.io/oskvr37/tiddl:latest
     volumes:
       - /downloads/dir:/root/Music/Tiddl/ #default dir
       - ./config/tiddl/:/root/ # Default location of config file 


### PR DESCRIPTION
Added _ghcr.io/oskvr37/tiddl:latest_ in _docker-compose.yml_ example code and _docker run_ example code, in **README.md** 

_The URL won't go live until a new package is released  / there's a version bump, which will trigger the automatic workflow, but that will be the correct latest version URL once it's live._