### PR TITLE
FLAC: set cover type to Front (3) and clear existing pictures

### DIFF
--- a/tiddl/metadata.py
+++ b/tiddl/metadata.py
@@ -38,6 +38,8 @@ def addMetadata(
             picture = Picture()
             picture.data = cover_data
             picture.mime = "image/jpeg"
+            picture.type = 3
+            metadata.clear_pictures()
             metadata.add_picture(picture)
 
         metadata["TITLE"] = track.title + (


### PR DESCRIPTION
Currently embedded images for FLAC files are getting saved as type 'Other'. 
Not all media players will check this for cover art. 
This PR saves the embedded cover art as 'Front' type 