### PR TITLE
Revert "🐛 Fix artists order"

### DIFF
--- a/tiddl/utils.py
+++ b/tiddl/utils.py
@@ -81,7 +81,7 @@ def formatTrack(
         "title": sanitizeString(track.title),
         "version": sanitizeString(track.version or ""),
         "artist": artist,
-        "artists": ", ".join([artist] + features),
+        "artists": ", ".join(features + [artist]),
         "features": ", ".join(features),
         "album": sanitizeString(track.album.title),
         "number": track.trackNumber,


### PR DESCRIPTION
Reverts oskvr37/tiddl#189
fixed wrong function.
formatTrack should be depracated as it is unused.