### PR TITLE
feat: Add `--skip-errors` flag to skip unavailable items during download (fix #267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ Run `tiddl download` to see available download options.
 
 ### Error Handling
 
-When downloading playlists or large collections, some items may be unavailable (e.g., removed from Tidal, region-locked). Use the `--skip-errors` flag to automatically skip unavailable items and continue downloading the rest:
+By default, tiddl stops when encountering unavailable items in collections such as playlists, albums, artists, or mixes (e.g., removed or region-locked tracks).
+
+Use `--skip-errors` to automatically skip these items and continue downloading:
 
 ```bash
 tiddl download url <url> --skip-errors
 ```
 
-Without this flag, tiddl will stop on the first error. With `--skip-errors`, unavailable items are logged with detailed information (track name, IDs) and skipped.
+Skipped items are logged with track/album name and IDs for reference.
 
 ### Quality
 

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -323,19 +323,34 @@ def download_callback(
                             )
                             continue
 
-                        futures.append(
-                            handle_item(
-                                item=album_item.item,
-                                file_path=file_path,
-                                track_metadata=Metadata(
-                                    cover=cover,
-                                    date=str(album.releaseDate),
-                                    artist=album.artist.name if album.artist else "",
-                                    credits=album_item.credits,
-                                    album_review=album_review,
-                                ),
+                        try:
+                            futures.append(
+                                handle_item(
+                                    item=album_item.item,
+                                    file_path=file_path,
+                                    track_metadata=Metadata(
+                                        cover=cover,
+                                        date=str(album.releaseDate),
+                                        artist=album.artist.name if album.artist else "",
+                                        credits=album_item.credits,
+                                        album_review=album_review,
+                                    ),
+                                )
                             )
-                        )
+                        except ApiError as e:
+                            item = album_item.item
+                            track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
+                            if hasattr(item, 'album') and item.album:
+                                track_info += f", Album ID: {item.album.id}"
+                            ctx.obj.console.print(f"[red]API Error:[/] {e} ({track_info})")
+                            if not SKIP_ERRORS:
+                                raise
+                        except Exception as e:
+                            item = album_item.item
+                            track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
+                            ctx.obj.console.print(f"[red]Error:[/] {e} ({track_info})")
+                            if not SKIP_ERRORS:
+                                raise
 
                     offset += album_items.limit
                     if offset >= album_items.totalNumberOfItems:
@@ -397,12 +412,19 @@ def download_callback(
 
                 case "video":
                     video = ctx.obj.api.get_video(resource.id)
+                    template = TEMPLATE or CONFIG.templates.video
+
+                    if "{album" in template and video.album:
+                        album = ctx.obj.api.get_album(video.album.id)
+                    else:
+                        album = None
 
                     await handle_item(
                         item=video,
                         file_path=format_template(
-                            template=TEMPLATE or CONFIG.templates.video,
+                            template=template,
                             item=video,
+                            album=album,
                             quality=get_item_quality(video),
                         ),
                     )
@@ -415,17 +437,40 @@ def download_callback(
                         mix_items = ctx.obj.api.get_mix_items(resource.id, offset=0)
 
                         for mix_item in mix_items.items:
-                            futures.append(
-                                handle_item(
-                                    item=mix_item.item,
-                                    file_path=format_template(
-                                        template=TEMPLATE or CONFIG.templates.mix,
+                            template = TEMPLATE or CONFIG.templates.mix
+
+                            try:
+                                if "{album" in template:
+                                    album = ctx.obj.api.get_album(
+                                        mix_item.item.album.id
+                                    )
+                                else:
+                                    album = None
+
+                                futures.append(
+                                    handle_item(
                                         item=mix_item.item,
-                                        mix_id=resource.id,
-                                        quality=get_item_quality(mix_item.item),
-                                    ),
+                                        file_path=format_template(
+                                            template=template,
+                                            item=mix_item.item,
+                                            album=album,
+                                            mix_id=resource.id,
+                                            quality=get_item_quality(mix_item.item),
+                                        ),
+                                    )
                                 )
-                            )
+                            except ApiError as e:
+                                item = mix_item.item
+                                track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
+                                ctx.obj.console.print(f"[red]API Error:[/] {e} ({track_info})")
+                                if not SKIP_ERRORS:
+                                    raise
+                            except Exception as e:
+                                item = mix_item.item
+                                track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
+                                ctx.obj.console.print(f"[red]Error:[/] {e} ({track_info})")
+                                if not SKIP_ERRORS:
+                                    raise
 
                         offset += mix_items.limit
                         if offset >= mix_items.totalNumberOfItems:
@@ -437,6 +482,7 @@ def download_callback(
                         resource_type="mix",
                         filename=format_template(
                             CONFIG.m3u.templates.mix,
+                            mix_id=resource.id,
                             type="mix",
                         ),
                         tracks_with_path=tracks_with_path,
@@ -449,6 +495,18 @@ def download_callback(
                 case "artist":
                     futures = []
 
+                    async def safe_download_album(album: Album):
+                        try:
+                            await download_album(album)
+                        except ApiError as e:
+                            ctx.obj.console.print(f"[red]API Error:[/] {e} (Album: {album.title}, ID: {album.id})")
+                            if not SKIP_ERRORS:
+                                raise
+                        except Exception as e:
+                            ctx.obj.console.print(f"[red]Error:[/] {e} (Album: {album.title}, ID: {album.id})")
+                            if not SKIP_ERRORS:
+                                raise
+
                     def get_all_albums(singles: bool):
                         offset = 0
 
@@ -460,7 +518,7 @@ def download_callback(
                             )
 
                             for album in artist_albums.items:
-                                futures.append(download_album(album))
+                                futures.append(safe_download_album(album))
 
                             offset += artist_albums.limit
                             if offset >= artist_albums.totalNumberOfItems:
@@ -475,16 +533,33 @@ def download_callback(
                             )
 
                             for video in artist_videos.items:
-                                futures.append(
-                                    handle_item(
-                                        item=video,
-                                        file_path=format_template(
-                                            template=TEMPLATE or CONFIG.templates.video,
+                                template = TEMPLATE or CONFIG.templates.video
+
+                                try:
+                                    if "{album" in template and video.album:
+                                        album = ctx.obj.api.get_album(video.album.id)
+                                    else:
+                                        album = None
+
+                                    futures.append(
+                                        handle_item(
                                             item=video,
-                                            quality=get_item_quality(video),
-                                        ),
+                                            file_path=format_template(
+                                                template=template,
+                                                item=video,
+                                                album=album,
+                                                quality=get_item_quality(video),
+                                            ),
+                                        )
                                     )
-                                )
+                                except ApiError as e:
+                                    ctx.obj.console.print(f"[red]API Error:[/] {e} (Video: {video.title}, ID: {video.id})")
+                                    if not SKIP_ERRORS:
+                                        raise
+                                except Exception as e:
+                                    ctx.obj.console.print(f"[red]Error:[/] {e} (Video: {video.title}, ID: {video.id})")
+                                    if not SKIP_ERRORS:
+                                        raise
 
                             if offset > artist_videos.totalNumberOfItems:
                                 break


### PR DESCRIPTION
- Small fix/implementation for this issue: https://github.com/oskvr37/tiddl/issues/267
- little bit improved error logging
- updated README for usage 

## Before fix

```
API Error: Album [156815873] not found, 404/2001 (playlist/fa394a3d-3a2f-44e0-bd1c-REDACTED)
/redacted/tiddl/cli/commands/download/__init__.py:577: RuntimeWarning: coroutine 'download_callback.<locals>.download_resources.<locals>.handle_resource.<locals>.handle_item' was never awaited
  ctx.obj.console.print(f"[red]API Error:[/] {e} ({r})")
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Total downloads: 0
```

## After fix

```
API Error: Album [156815873] not found, 404/2001 (Track: Who Knows (ID: 156815876), Album ID: 156815873)
API Error: Album [92692168] not found, 404/2001 (Track: Only Just Begun (ID: 92692169), Album ID: 92692168)
Downloaded Herbalist  16-bit, 44.1 kHz /redacted/Music/tiddl/Alborosie/Soul Pirate
Downloaded Lesson  16-bit, 44.1 kHz /redacted/Music/tiddl/Chezidek/Irie Day
...
Total downloads: 21
```

Hope this helps, Cheers :)