### PR TITLE
feat: Add skip_unavailable_tracks flag and persist skip_errors in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,34 @@ Run `tiddl download` to see available download options.
 
 ### Error Handling
 
-By default, tiddl stops when encountering unavailable items in collections such as playlists, albums, artists, or mixes (e.g., removed or region-locked tracks).
+By default, tiddl stops when it encounters a problem with an item in a collection (playlist, album, artist, mix). Two flags control this behaviour, each covering a different failure point:
 
-Use `--skip-errors` to automatically skip these items and continue downloading:
+#### `--skip-errors` / `skip_errors`
+
+Skips items that fail **during download** — for example a track whose album has been deleted, or a region-locked stream — and continues with the rest of the collection.
 
 ```bash
 tiddl download url <url> --skip-errors
 ```
 
-Skipped items are logged with track/album name and IDs for reference.
+#### `--skip-unavailable-tracks` / `skip_unavailable_tracks`
+
+Skips tracks that are **entirely unavailable on Tidal** (no ISRC assigned). These appear in playlists and mixes as placeholder entries and can never be downloaded. This filter runs at fetch time, before `--skip-errors` would have a chance to act, so both flags are needed for full coverage.
+
+```bash
+tiddl download url <url> --skip-unavailable-tracks
+```
+
+> [!TIP]
+> For most users, enabling **both flags together** is the recommended setup. It makes tiddl download everything it can and silently skip anything it can't, covering all known failure points. Without both, a single unavailable track can stop an entire playlist download.
+
+Both flags are logged so you can always see which tracks were skipped and why. Set them permanently in `config.toml` so you never have to pass them on the command line:
+
+```toml
+[download]
+skip_errors = true
+skip_unavailable_tracks = true
+```
 
 ### Quality
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -89,15 +89,16 @@ disable_live = false
 # skipped items are logged with their name and ID for reference.
 skip_errors = false
 
-# skip tracks that are entirely unavailable on Tidal (no ISRC assigned).
+# skip tracks that are entirely unavailable on Tidal (no ISRC assigned or not stream-ready).
 # these tracks appear in playlists/mixes as placeholders and can never be downloaded.
-# when disabled and such a track is encountered, tiddl will stop with a validation error.
+# note: tracks with streamReady=false are always skipped with a warning regardless of this flag.
+# enabling this flag filters them out earlier, at fetch time, which is more efficient.
 # note: this works at fetch time, before skip_errors can act, so both flags serve different purposes.
 skip_unavailable_tracks = false
 
 # tip: enabling both skip_errors and skip_unavailable_tracks together is the recommended setup
 # for downloading playlists or large collections. it makes tiddl download everything it can
-# and skip anything it can't, covering all known failure points.
+# and skip anything it can't.
 
 
 [metadata]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -37,7 +37,7 @@ default = "{album.artist}/{album.title}/{item.title}"
 # low - 96 kbps, m4a
 # normal - 320 kbps, m4a
 # high - 16 bit, 44.1 kHz, flac
-# max - up to 24 bit, 192 kHz, flac 
+# max - up to 24 bit, 192 kHz, flac
 track_quality = "high"
 
 # sd - 360p
@@ -79,6 +79,25 @@ update_mtime = false
 # when enabled, it will write metadata to files that are already downloaded.
 # could be useful when data on Tidal has changed.
 rewrite_metadata = false
+
+# disable Rich Live display during downloads.
+# useful for debugging with breakpoint() as Live overlaps with debugger output.
+disable_live = false
+
+# skip items that fail during download (e.g. region-locked tracks, deleted albums)
+# and continue downloading the rest of the collection instead of stopping.
+# skipped items are logged with their name and ID for reference.
+skip_errors = false
+
+# skip tracks that are entirely unavailable on Tidal (no ISRC assigned).
+# these tracks appear in playlists/mixes as placeholders and can never be downloaded.
+# when disabled and such a track is encountered, tiddl will stop with a validation error.
+# note: this works at fetch time, before skip_errors can act, so both flags serve different purposes.
+skip_unavailable_tracks = false
+
+# tip: enabling both skip_errors and skip_unavailable_tracks together is the recommended setup
+# for downloading playlists or large collections. it makes tiddl download everything it can
+# and skip anything it can't, covering all known failure points.
 
 
 [metadata]

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -455,34 +455,39 @@ def download_callback(
                         for mix_item in mix_items.items:
                             template = TEMPLATE or CONFIG.templates.mix
 
+                            item = mix_item.item
+                            if not getattr(item, "streamReady", True):
+                                ctx.obj.console.print(
+                                    f"[yellow]Skipping unavailable track:[/] {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
+                                )
+                                continue
+
                             try:
                                 if "{album" in template:
                                     album = ctx.obj.api.get_album(
-                                        mix_item.item.album.id
+                                        item.album.id
                                     )
                                 else:
                                     album = None
 
                                 futures.append(
                                     handle_item(
-                                        item=mix_item.item,
+                                        item=item,
                                         file_path=format_template(
                                             template=template,
-                                            item=mix_item.item,
+                                            item=item,
                                             album=album,
                                             mix_id=resource.id,
-                                            quality=get_item_quality(mix_item.item),
+                                            quality=get_item_quality(item),
                                         ),
                                     )
                                 )
                             except ApiError as e:
-                                item = mix_item.item
                                 track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
                                 ctx.obj.console.print(f"[red]API Error:[/] {e} ({track_info})")
                                 if not SKIP_ERRORS:
                                     raise
                             except Exception as e:
-                                item = mix_item.item
                                 track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
                                 ctx.obj.console.print(f"[red]Error:[/] {e} ({track_info})")
                                 if not SKIP_ERRORS:
@@ -609,30 +614,36 @@ def download_callback(
                             playlist_index += 1
                             template = TEMPLATE or CONFIG.templates.playlist
 
+                            item = playlist_item.item
+                            if not getattr(item, "streamReady", True):
+                                ctx.obj.console.print(
+                                    f"[yellow]Skipping unavailable track:[/] {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
+                                )
+                                continue
+
                             try:
                                 if "{album" in template:
                                     album = ctx.obj.api.get_album(
-                                        playlist_item.item.album.id
+                                        item.album.id
                                     )
                                 else:
                                     album = None
 
                                 futures.append(
                                     handle_item(
-                                        item=playlist_item.item,
+                                        item=item,
                                         file_path=format_template(
                                             template=template,
-                                            item=playlist_item.item,
+                                            item=item,
                                             album=album,
                                             playlist=playlist,
                                             playlist_index=playlist_index,
-                                            quality=get_item_quality(playlist_item.item),
+                                            quality=get_item_quality(item),
                                         ),
                                         track_metadata=Metadata(),
                                     )
                                 )
                             except ApiError as e:
-                                item = playlist_item.item
                                 track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
                                 if hasattr(item, 'album') and item.album:
                                     track_info += f", Album ID: {item.album.id}"
@@ -640,7 +651,6 @@ def download_callback(
                                 if not SKIP_ERRORS:
                                     raise
                             except Exception as e:
-                                item = playlist_item.item
                                 track_info = f"Track: {getattr(item, 'title', 'Unknown')} (ID: {item.id})"
                                 ctx.obj.console.print(f"[red]Error:[/] {e} ({track_info})")
                                 if not SKIP_ERRORS:

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -125,7 +125,23 @@ def download_callback(
             "-se",
             help="Skip unavailable items and continue downloading the rest.",
         ),
-    ] = False,
+    ] = CONFIG.download.skip_errors,
+    DISABLE_LIVE: Annotated[
+        bool,
+        typer.Option(
+            "--disable-live",
+            "-dl",
+            help="Disable Rich Live display, useful for debugging with breakpoint().",
+        ),
+    ] = CONFIG.download.disable_live,
+    SKIP_UNAVAILABLE_TRACKS: Annotated[
+        bool,
+        typer.Option(
+            "--skip-unavailable-tracks",
+            "-sut",
+            help="Skip tracks that are unavailable (no ISRC) instead of attempting to download them.",
+        ),
+    ] = CONFIG.download.skip_unavailable_tracks,
 ):
     """
     Download Tidal resources.
@@ -434,7 +450,7 @@ def download_callback(
                     futures = []
 
                     while True:
-                        mix_items = ctx.obj.api.get_mix_items(resource.id, offset=0)
+                        mix_items = ctx.obj.api.get_mix_items(resource.id, offset=0, skip_unavailable_tracks=SKIP_UNAVAILABLE_TRACKS)
 
                         for mix_item in mix_items.items:
                             template = TEMPLATE or CONFIG.templates.mix
@@ -586,7 +602,7 @@ def download_callback(
 
                     while True:
                         playlist_items = ctx.obj.api.get_playlist_items(
-                            playlist_uuid=resource.id, offset=offset
+                            playlist_uuid=resource.id, offset=offset, skip_unavailable_tracks=SKIP_UNAVAILABLE_TRACKS
                         )
 
                         for playlist_item in playlist_items.items:

--- a/tiddl/cli/config.py
+++ b/tiddl/cli/config.py
@@ -55,6 +55,9 @@ class Config(BaseModel):
         videos_filter: VIDEOS_FILTER_LITERAL = "none"
         update_mtime: bool = False
         rewrite_metadata: bool = False
+        disable_live: bool = False
+        skip_errors: bool = False
+        skip_unavailable_tracks: bool = False
 
         def model_post_init(self, __context):
             # set scan path to download path when download path is non default

--- a/tiddl/core/api/api.py
+++ b/tiddl/core/api/api.py
@@ -65,7 +65,7 @@ class TidalAPI:
 
     @staticmethod
     def _filter_unavailable_items(data: dict) -> dict:
-        """Remove items whose track has no ISRC (unavailable/region-locked tracks).
+        """Remove items whose track has no ISRC or is not stream-ready.
 
         Short-circuits if nothing is filtered to avoid unnecessary allocation.
         """
@@ -73,7 +73,7 @@ class TidalAPI:
         available = []
         for i in items:
             track = i.get("item")
-            if track and track.get("isrc") is not None:
+            if track and track.get("isrc") is not None and track.get("streamReady", True):
                 available.append(i)
             else:
                 log.warning(


### PR DESCRIPTION
## Summary

- Adds `skip_unavailable_tracks` flag (config + `--skip-unavailable-tracks` / `-sut` CLI option) to filter out tracks with no ISRC or `streamReady=false` before Pydantic validation. These are placeholder entries in playlists/mixes that Tidal marks as unavailable and can never be downloaded.
- Promotes `skip_errors` from a CLI-only flag to a persistent config option, so users no longer need to pass `--skip-errors` on every run.
- Adds a `pre_validate` hook to `TidalClient.fetch()` used to strip unavailable items from raw API data before model validation runs.
- Moves the filter logic into a `TidalAPI._filter_unavailable_items()` static method (checking both missing ISRC and `streamReady=false`) with a short-circuit optimisation (no allocation when nothing is filtered).
- Adds an unconditional `streamReady` guard in the playlist and mix item loops: tracks with `streamReady=false` are always skipped with a yellow warning before any album API call is made, preventing a crash when the track's album has also been removed from Tidal.
- Updates `docs/config.example.toml` and `README.md` to document both flags, explain the difference between them, and recommend enabling both together for uninterrupted playlist/collection downloads.

## Why all three layers are needed

| Layer | Failure point | Example |
|---|---|---|
| `skip_unavailable_tracks` | Fetch time — before the download loop | Track with `isrc: null` or `streamReady: false` causes a Pydantic `ValidationError` for the whole batch |
| Built-in `streamReady` guard | Per-item — before album fetch in the loop | Track with `streamReady: false` whose album was also removed from Tidal; the album `GET` returns 404 and previously crashed the entire playlist download |
| `skip_errors` | Per-item — inside the download loop | Track whose album was deleted returns a 404 `ApiError` during download |

The `streamReady` guard is always active regardless of flags — a non-streamable track can never be downloaded, so attempting an album fetch for it was both wasteful and a crash vector. Enabling `skip_unavailable_tracks` as well filters these tracks out earlier at fetch time, which is more efficient. Enabling `skip_errors` on top of that handles any remaining per-item failures. Together they make tiddl download everything it can and skip anything it can't — the recommended setup for large playlists or collections.
