### PR TITLE
Enable system proxy support by setting trust_env=True in aiohttp.ClientSession

### DIFF
--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -173,7 +173,7 @@ class Downloader:
             with NamedTemporaryFile(
                 "wb", delete=False, dir=download_path.parent
             ) as tmp:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(trust_env=True) as session:
                     async with aiofiles.open(tmp.name, "wb") as f:
                         for url in urls:
                             async with session.get(url) as resp:


### PR DESCRIPTION
By default, aiohttp ignores environment variables. This change allows tiddl to respect system-level proxy configurations (such as HTTP_PROXY and HTTPS_PROXY) defined in the user's environment.