### PR TITLE
fix: change birthday, created, and updated types of Auth model to support str

### DIFF
--- a/tiddl/core/auth/models.py
+++ b/tiddl/core/auth/models.py
@@ -17,12 +17,12 @@ class AuthResponse(BaseModel):
         postalcode: Optional[str]
         usState: Optional[str]
         phoneNumber: Optional[str]
-        birthday: Optional[int]
+        birthday: Optional[int | str]
         channelId: int
         parentId: int
         acceptedEULA: bool
-        created: int
-        updated: int
+        created: int | str
+        updated: int | str
         facebookUid: int
         appleUid: Optional[str]
         googleUid: Optional[str]


### PR DESCRIPTION
Resolves issue #299.

int | str is used instead of updating the type to only "str" because the API change appears to have been introduced quietly and may revert in the future. Since the exact type of these fields is not critical for the library, supporting both types provides a safer and more resilient approach.