### PR TITLE
🐛 Fixed album/playlist validation errors

### DIFF
--- a/tiddl/core/api/models/resources.py
+++ b/tiddl/core/api/models/resources.py
@@ -134,7 +134,7 @@ class Album(BaseModel):
     vibrantColor: Optional[str] = None
     videoCover: Optional[str] = None
     explicit: bool
-    upc: str
+    upc: Optional[str] = None
     popularity: int
     audioQuality: str
     audioModes: List[str]
@@ -163,7 +163,7 @@ class Playlist(BaseModel):
     url: str
     image: Optional[str] = None
     popularity: int
-    squareImage: str
+    squareImage: Optional[str] = None
     promotedArtists: List[Album.Artist]
     lastItemAddedAt: Optional[str] = None
 


### PR DESCRIPTION
Made two model fields optional for the validation engine.

* `upc` field in the `MediaMetadata` model optional - unused field
* `squareImage` field in the `Playlist` model optional - used when downloading covers
