### PR TITLE
fix: make facebookUid optional in auth response model

### DIFF
--- a/tiddl/core/auth/models.py
+++ b/tiddl/core/auth/models.py
@@ -23,7 +23,7 @@ class AuthResponse(BaseModel):
         acceptedEULA: bool
         created: int | str
         updated: int | str
-        facebookUid: int
+        facebookUid: Optional[int] = None
         appleUid: Optional[str]
         googleUid: Optional[str]
         accountLinkCreated: bool


### PR DESCRIPTION
## Problem

Tidal no longer returns `facebookUid` in the auth API response. Since the field is declared as `facebookUid: int` (required) in the Pydantic model, `model_validate` raises a `ValidationError` and authentication fails entirely:

```
ValidationError: 1 validation error for AuthResponseWithRefresh
user.facebookUid
  Field required [type=missing, ...]
```

## Fix

Mark the field `Optional[int] = None`. In Pydantic v2, `Optional[int]` alone still marks the field as required — the `= None` default is needed to allow the field to be absent from the response.

## Testing

Verified on a live Tidal account: `tiddl auth login` completes successfully after this change.