### PR TITLE
✨ Added list_separator config option for artist lists

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -98,6 +98,11 @@ match_existing_path_case = false
 # (both versions won't be downloaded at a time, it depends on what Tidal returns)
 atmos_filter = "none"
 
+# separator used when joining multiple artists in filenames and metadata.
+# default is "; " (semicolon + space), e.g. "Artist1; Artist2"
+# set to ", " for "Artist1, Artist2", " & " for "Artist1 & Artist2", or "/" for "Artist1/Artist2"
+# list_separator = "; "
+
 
 [metadata]
 # embed metadata in files

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -75,3 +75,20 @@ def test_invalid_track_quality_raises(tmp_path: Path):
 
     with raises(Exception):
         load_config_file(cfg_file)
+
+
+def test_list_separator_default(tmp_path: Path):
+    cfg = load_config_file(tmp_path / "nonexistent.toml")
+    assert cfg.download.list_separator == "; "
+
+
+def test_list_separator_custom(tmp_path: Path):
+    cfg_file = write_config(
+        tmp_path,
+        """
+        [download]
+        list_separator = ", "
+        """,
+    )
+    cfg = load_config_file(cfg_file)
+    assert cfg.download.list_separator == ", "

--- a/tests/core/utils/test_utils_format.py
+++ b/tests/core/utils/test_utils_format.py
@@ -89,6 +89,90 @@ class TestFormatTemplateNoAlbum:
         assert result == "Gorillaz"
 
 
+MULTI_ARTIST_VIDEO = Video.model_validate(
+    {
+        "id": 2,
+        "title": "Collab",
+        "volumeNumber": 1,
+        "trackNumber": 1,
+        "duration": 200,
+        "quality": "MP4_1080P",
+        "streamReady": True,
+        "adSupportedStreamReady": False,
+        "djReady": False,
+        "stemReady": False,
+        "allowStreaming": True,
+        "explicit": False,
+        "popularity": 10,
+        "type": "Music Video",
+        "adsPrePaywallOnly": False,
+        "artists": [
+            {"id": 1, "name": "Artist A", "type": "MAIN"},
+            {"id": 2, "name": "Artist B", "type": "MAIN"},
+        ],
+        "artist": {"id": 1, "name": "Artist A", "type": "MAIN"},
+    }
+)
+
+
+class TestListSeparator:
+    def test_default_separator_in_template(self):
+        result = format_template(
+            template="{item.artists}",
+            item=MULTI_ARTIST_VIDEO,
+            album=None,
+            with_asterisk_ext=False,
+        )
+        assert result == "Artist A; Artist B"
+
+    def test_custom_separator_in_template(self):
+        result = format_template(
+            template="{item.artists}",
+            item=MULTI_ARTIST_VIDEO,
+            album=None,
+            with_asterisk_ext=False,
+            list_separator=", ",
+        )
+        assert result == "Artist A, Artist B"
+
+    def test_ampersand_separator_in_template(self):
+        result = format_template(
+            template="{item.artists}",
+            item=MULTI_ARTIST_VIDEO,
+            album=None,
+            with_asterisk_ext=False,
+            list_separator=" & ",
+        )
+        assert result == "Artist A & Artist B"
+
+    def test_separator_applied_to_features(self):
+        video = Video.model_validate(
+            {
+                **MULTI_ARTIST_VIDEO.model_dump(),
+                "artists": [
+                    {"id": 1, "name": "Main", "type": "MAIN"},
+                    {"id": 2, "name": "Feat A", "type": "FEATURED"},
+                    {"id": 3, "name": "Feat B", "type": "FEATURED"},
+                ],
+            }
+        )
+        data = generate_template_data(item=video, list_separator=" & ")
+        assert data["item"].features == "Feat A & Feat B"
+
+    def test_separator_applied_to_artists_with_features(self):
+        video = Video.model_validate(
+            {
+                **MULTI_ARTIST_VIDEO.model_dump(),
+                "artists": [
+                    {"id": 1, "name": "Main", "type": "MAIN"},
+                    {"id": 2, "name": "Feat", "type": "FEATURED"},
+                ],
+            }
+        )
+        data = generate_template_data(item=video, list_separator=" / ")
+        assert data["item"].artists_with_features == "Main / Feat"
+
+
 class TestGenerateTemplateDataAlbumFallback:
     def test_album_template_is_never_none(self):
         """generate_template_data should always return an AlbumTemplate, never None."""

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -295,10 +295,11 @@ def download_callback(
                             date=track_metadata.date,
                             credits_contributors=track_metadata.credits,
                             comment=track_metadata.album_review,
+                            list_separator=CONFIG.download.list_separator,
                         )
 
                     elif isinstance(item, Video):
-                        add_video_metadata(path=download_path, video=item)
+                        add_video_metadata(path=download_path, video=item, list_separator=CONFIG.download.list_separator)
 
                 if download_path and CONFIG.download.update_mtime:
                     try:
@@ -341,6 +342,7 @@ def download_callback(
                                 item=album_item.item,
                                 album=album,
                                 quality=get_item_quality(album_item.item),
+                                list_separator=CONFIG.download.list_separator,
                             )
 
                         except AttributeError as exc:
@@ -430,6 +432,7 @@ def download_callback(
                             item=track,
                             album=album,
                             quality=get_item_quality(track),
+                            list_separator=CONFIG.download.list_separator,
                         ),
                         track_metadata=Metadata(
                             cover=cover,
@@ -449,7 +452,8 @@ def download_callback(
                         ).save_to_directory(
                             path=DOWNLOAD_PATH
                             / format_template(
-                                CONFIG.cover.templates.track, item=track, album=album
+                                CONFIG.cover.templates.track, item=track, album=album,
+                                list_separator=CONFIG.download.list_separator,
                             )
                         )
 
@@ -473,6 +477,7 @@ def download_callback(
                             item=video,
                             album=album,
                             quality=get_item_quality(video),
+                            list_separator=CONFIG.download.list_separator,
                         ),
                     )
 
@@ -503,6 +508,7 @@ def download_callback(
                                             album=album,
                                             mix_id=resource.id,
                                             quality=get_item_quality(mix_item.item),
+                                            list_separator=CONFIG.download.list_separator,
                                         ),
                                     )
                                 )
@@ -604,6 +610,7 @@ def download_callback(
                                                 item=video,
                                                 album=album,
                                                 quality=get_item_quality(video),
+                                                list_separator=CONFIG.download.list_separator,
                                             ),
                                         )
                                     )
@@ -672,6 +679,7 @@ def download_callback(
                                             quality=get_item_quality(
                                                 playlist_item.item
                                             ),
+                                            list_separator=CONFIG.download.list_separator,
                                         ),
                                         track_metadata=Metadata(),
                                     )

--- a/tiddl/cli/config.py
+++ b/tiddl/cli/config.py
@@ -59,6 +59,7 @@ class Config(BaseModel):
         write_lrc_file: bool = False
         match_existing_path_case: bool = False
         atmos_filter: ATMOS_FILTER_LITERAL = "none"
+        list_separator: str = "; "
 
         def model_post_init(self, __context):
             # set scan path to download path when download path is non default

--- a/tiddl/core/metadata/track.py
+++ b/tiddl/core/metadata/track.py
@@ -35,7 +35,7 @@ class Metadata:
     comment: str = ""
 
 
-def add_flac_metadata(track_path: Path, metadata: Metadata) -> None:
+def add_flac_metadata(track_path: Path, metadata: Metadata, list_separator: str = "; ") -> None:
     log.debug(f"{track_path=}")
 
     mutagen = MutagenFLAC(track_path)
@@ -59,7 +59,7 @@ def add_flac_metadata(track_path: Path, metadata: Metadata) -> None:
             "DISCNUMBER": metadata.disc_number,
             "ALBUM": metadata.album_title,
             "ALBUMARTIST": metadata.album_artist,
-            "ARTIST": metadata.artists,
+            "ARTIST": [list_separator.join(metadata.artists)],
             "DATE": str(date) if date else "",
             "YEAR": (str(date.year) if date else ""),
             "COPYRIGHT": metadata.copyright or "",
@@ -79,7 +79,7 @@ def add_flac_metadata(track_path: Path, metadata: Metadata) -> None:
     mutagen.save()
 
 
-def add_m4a_metadata(track_path: Path, metadata: Metadata) -> None:
+def add_m4a_metadata(track_path: Path, metadata: Metadata, list_separator: str = "; ") -> None:
     mutagen = MutagenMP4(track_path)
 
     if metadata.cover_data:
@@ -101,7 +101,7 @@ def add_m4a_metadata(track_path: Path, metadata: Metadata) -> None:
             "discnumber": metadata.disc_number,
             "album": metadata.album_title,
             "albumartist": metadata.album_artist,
-            "artist": ["; ".join(metadata.artists)],
+            "artist": [list_separator.join(metadata.artists)],
             "date": metadata.date,
             "copyright": metadata.copyright or "",
             "comment": metadata.comment,
@@ -174,6 +174,7 @@ def add_track_metadata(
         list[AlbumItemsCredits.ItemWithCredits.CreditsEntry] | None
     ) = None,
     comment: str = "",
+    list_separator: str = "; ",
 ) -> None:
     """Add FLAC or M4A metadata based on file extension."""
 
@@ -203,8 +204,8 @@ def add_track_metadata(
     ext = path.suffix.lower()
 
     if ext == ".flac":
-        add_flac_metadata(path, metadata)
+        add_flac_metadata(path, metadata, list_separator=list_separator)
     elif ext == ".m4a":
-        add_m4a_metadata(path, metadata)
+        add_m4a_metadata(path, metadata, list_separator=list_separator)
     else:
         raise ValueError(f"Unsupported file extension: {ext}")

--- a/tiddl/core/metadata/video.py
+++ b/tiddl/core/metadata/video.py
@@ -3,13 +3,13 @@ from mutagen.easymp4 import EasyMP4 as MutagenEasyMP4
 from tiddl.core.api.models import Video
 
 
-def add_video_metadata(path: Path, video: Video):
+def add_video_metadata(path: Path, video: Video, list_separator: str = "; "):
     mutagen = MutagenEasyMP4(path)
 
     mutagen.update(
         {
             "title": video.title,
-            "artist": "; ".join([artist.name.strip() for artist in video.artists]),
+            "artist": list_separator.join([artist.name.strip() for artist in video.artists]),
         }
     )
 

--- a/tiddl/core/utils/format.py
+++ b/tiddl/core/utils/format.py
@@ -112,6 +112,7 @@ def generate_template_data(
     playlist: Playlist | None = None,
     playlist_index: int = 0,
     quality: str = "",
+    list_separator: str = "; ",
 ) -> dict[str, ItemTemplate | AlbumTemplate | PlaylistTemplate | None]:
     """Normalize Tidal API Track/Video + Album data into safe templates."""
 
@@ -149,9 +150,9 @@ def generate_template_data(
             isrc=isrc,
             quality=quality,
             artist=item.artist.name if item.artist else "",
-            artists="; ".join(main_artists),
-            features="; ".join(featured_artists),
-            artists_with_features="; ".join(main_artists + featured_artists),
+            artists=list_separator.join(main_artists),
+            features=list_separator.join(featured_artists),
+            artists_with_features=list_separator.join(main_artists + featured_artists),
             explicit=Explicit(getattr(item, "explicit", None)),
             dolby=dolby,
         )
@@ -200,6 +201,7 @@ def format_template(
     playlist_index: int = 0,
     quality: str = "",
     with_asterisk_ext: bool = True,
+    list_separator: str = "; ",
     **extra,
 ) -> str:
     """
@@ -215,6 +217,7 @@ def format_template(
             playlist=playlist,
             playlist_index=playlist_index,
             quality=quality,
+            list_separator=list_separator,
         )
         | extra
         | custom_fields


### PR DESCRIPTION
Adds a `list_separator` option under `[download]` in `config.toml` that controls the string used to join multiple artists in filenames and metadata.

**Default:** `"; "` — preserves existing behaviour.

**Example:**
```toml
[download]
list_separator = ", "
```

Changes:
- `DownloadConfig.list_separator: str = "; "`
- `generate_template_data()` and `format_template()` accept `list_separator` and apply it to `{item.artists}`, `{item.features}`, and `{item.artists_with_features}`
- `add_track_metadata()` and `add_video_metadata()` accept `list_separator` and apply it to the FLAC `ARTIST` tag (joined into a single value) and the M4A `artist` tag
- All call sites in the download command pass `CONFIG.download.list_separator`
- `config.example.toml` documents the new option
