### PR TITLE
✨ Added fav_mtime config option to set file mtime from favorites date

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -76,6 +76,14 @@ videos_filter = "none"
 # that have been removed from a Tidal collection.
 update_mtime = false
 
+# when downloading favorites (tiddl download fav), set each file's modification
+# time to the date the item was added to your favorites.
+# for tracks and videos: uses the date that specific track/video was favorited.
+# for albums: all tracks in the album share the date the album was favorited.
+# does not apply to playlist or artist favorites.
+# if update_mtime is also enabled, it takes precedence and current time is used instead.
+fav_mtime = false
+
 # when enabled, it will write metadata to files that are already downloaded.
 # could be useful when data on Tidal has changed.
 rewrite_metadata = false

--- a/tests/cli/commands/test_mtime.py
+++ b/tests/cli/commands/test_mtime.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tiddl.cli.commands.download import _apply_mtime
+
+
+@pytest.fixture
+def tmp_file(tmp_path: Path) -> Path:
+    f = tmp_path / "track.flac"
+    f.write_bytes(b"")
+    return f
+
+
+def test_update_mtime_calls_utime_with_none(tmp_file):
+    with patch("tiddl.cli.commands.download.os.utime") as mock_utime:
+        _apply_mtime(tmp_file, update_mtime=True, fav_mtime=False, fav_date_added=None)
+    mock_utime.assert_called_once_with(tmp_file, None)
+
+
+def test_fav_mtime_sets_timestamp(tmp_file):
+    date_str = "2024-03-15T10:30:00"
+    expected_ts = datetime.fromisoformat(date_str).timestamp()
+
+    with patch("tiddl.cli.commands.download.os.utime") as mock_utime:
+        _apply_mtime(tmp_file, update_mtime=False, fav_mtime=True, fav_date_added=date_str)
+    mock_utime.assert_called_once_with(tmp_file, (expected_ts, expected_ts))
+
+
+def test_update_mtime_wins_over_fav_mtime(tmp_file):
+    """When update_mtime is set, fav_mtime is ignored and current time is used."""
+    date_str = "2024-03-15T10:30:00"
+
+    with patch("tiddl.cli.commands.download.os.utime") as mock_utime:
+        _apply_mtime(tmp_file, update_mtime=True, fav_mtime=True, fav_date_added=date_str)
+    mock_utime.assert_called_once_with(tmp_file, None)
+
+
+def test_fav_mtime_without_date_does_nothing(tmp_file):
+    with patch("tiddl.cli.commands.download.os.utime") as mock_utime:
+        _apply_mtime(tmp_file, update_mtime=False, fav_mtime=True, fav_date_added=None)
+    mock_utime.assert_not_called()
+
+
+def test_both_disabled_does_nothing(tmp_file):
+    with patch("tiddl.cli.commands.download.os.utime") as mock_utime:
+        _apply_mtime(tmp_file, update_mtime=False, fav_mtime=False, fav_date_added="2024-03-15T10:30:00")
+    mock_utime.assert_not_called()
+
+
+def test_fav_mtime_sets_correct_timestamp_on_real_file(tmp_file):
+    date_str = "2021-06-01T12:00:00+00:00"
+    expected_ts = datetime.fromisoformat(date_str).timestamp()
+
+    _apply_mtime(tmp_file, update_mtime=False, fav_mtime=True, fav_date_added=date_str)
+
+    assert tmp_file.stat().st_mtime == pytest.approx(expected_ts, abs=1)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -75,3 +75,20 @@ def test_invalid_track_quality_raises(tmp_path: Path):
 
     with raises(Exception):
         load_config_file(cfg_file)
+
+
+def test_fav_mtime_default(tmp_path: Path):
+    cfg = load_config_file(tmp_path / "nonexistent.toml")
+    assert cfg.download.fav_mtime is False
+
+
+def test_fav_mtime_enabled(tmp_path: Path):
+    cfg_file = write_config(
+        tmp_path,
+        """
+        [download]
+        fav_mtime = true
+        """,
+    )
+    cfg = load_config_file(cfg_file)
+    assert cfg.download.fav_mtime is True

--- a/tests/core/api/test_api_models_base.py
+++ b/tests/core/api/test_api_models_base.py
@@ -1,0 +1,150 @@
+import pytest
+from pydantic import ValidationError
+
+from tiddl.core.api.models.base import FavoriteAlbumsItems, FavoriteTracksItems, FavoriteVideosItems
+
+
+BASE_TRACK = {
+    "id": 1,
+    "title": "Test Track",
+    "duration": 180,
+    "replayGain": 0.0,
+    "peak": 1.0,
+    "allowStreaming": True,
+    "streamReady": True,
+    "adSupportedStreamReady": False,
+    "djReady": False,
+    "stemReady": False,
+    "premiumStreamingOnly": False,
+    "trackNumber": 1,
+    "volumeNumber": 1,
+    "popularity": 50,
+    "url": "https://tidal.com/track/1",
+    "isrc": "USAAA0000001",
+    "editable": False,
+    "explicit": False,
+    "audioQuality": "HIGH",
+    "audioModes": ["STEREO"],
+    "mediaMetadata": {"tags": []},
+    "artists": [],
+    "album": {"id": 1, "title": "Test Album"},
+}
+
+BASE_VIDEO = {
+    "id": 2,
+    "title": "Test Video",
+    "volumeNumber": 1,
+    "trackNumber": 1,
+    "duration": 240,
+    "quality": "MP4_1080P",
+    "streamReady": True,
+    "adSupportedStreamReady": False,
+    "djReady": False,
+    "stemReady": False,
+    "allowStreaming": True,
+    "explicit": False,
+    "popularity": 30,
+    "type": "Music Video",
+    "adsPrePaywallOnly": False,
+    "artists": [],
+}
+
+FAVORITE_TRACKS_PAYLOAD = {
+    "limit": 20,
+    "offset": 0,
+    "totalNumberOfItems": 1,
+    "items": [
+        {"item": BASE_TRACK, "type": "track", "created": "2024-03-15T10:30:00"},
+    ],
+}
+
+FAVORITE_VIDEOS_PAYLOAD = {
+    "limit": 20,
+    "offset": 0,
+    "totalNumberOfItems": 1,
+    "items": [
+        {"item": BASE_VIDEO, "type": "video", "created": "2024-06-01T08:00:00"},
+    ],
+}
+
+
+def test_favorite_tracks_items_parses():
+    result = FavoriteTracksItems.model_validate(FAVORITE_TRACKS_PAYLOAD)
+    assert result.totalNumberOfItems == 1
+    assert len(result.items) == 1
+    assert result.items[0].item.title == "Test Track"
+    assert result.items[0].created == "2024-03-15T10:30:00"
+
+
+def test_favorite_videos_items_parses():
+    result = FavoriteVideosItems.model_validate(FAVORITE_VIDEOS_PAYLOAD)
+    assert result.totalNumberOfItems == 1
+    assert len(result.items) == 1
+    assert result.items[0].item.title == "Test Video"
+    assert result.items[0].created == "2024-06-01T08:00:00"
+
+
+def test_favorite_tracks_missing_created_raises():
+    payload = {
+        **FAVORITE_TRACKS_PAYLOAD,
+        "items": [{"item": BASE_TRACK, "type": "track"}],
+    }
+    with pytest.raises(ValidationError):
+        FavoriteTracksItems.model_validate(payload)
+
+
+def test_favorite_tracks_pagination_fields():
+    payload = {**FAVORITE_TRACKS_PAYLOAD, "limit": 5, "offset": 10, "totalNumberOfItems": 50}
+    result = FavoriteTracksItems.model_validate(payload)
+    assert result.limit == 5
+    assert result.offset == 10
+    assert result.totalNumberOfItems == 50
+
+
+BASE_ALBUM = {
+    "id": 10,
+    "title": "Test Album",
+    "duration": 3600,
+    "streamReady": True,
+    "adSupportedStreamReady": False,
+    "djReady": False,
+    "stemReady": False,
+    "allowStreaming": True,
+    "premiumStreamingOnly": False,
+    "numberOfTracks": 10,
+    "numberOfVideos": 0,
+    "numberOfVolumes": 1,
+    "type": "ALBUM",
+    "url": "https://tidal.com/album/10",
+    "explicit": False,
+    "popularity": 80,
+    "audioQuality": "LOSSLESS",
+    "audioModes": ["STEREO"],
+    "mediaMetadata": {"tags": ["LOSSLESS"]},
+    "artists": [],
+}
+
+FAVORITE_ALBUMS_PAYLOAD = {
+    "limit": 20,
+    "offset": 0,
+    "totalNumberOfItems": 1,
+    "items": [
+        {"item": BASE_ALBUM, "type": "album", "created": "2023-11-20T15:45:00"},
+    ],
+}
+
+
+def test_favorite_albums_items_parses():
+    result = FavoriteAlbumsItems.model_validate(FAVORITE_ALBUMS_PAYLOAD)
+    assert result.totalNumberOfItems == 1
+    assert result.items[0].item.title == "Test Album"
+    assert result.items[0].created == "2023-11-20T15:45:00"
+
+
+def test_favorite_albums_missing_created_raises():
+    payload = {
+        **FAVORITE_ALBUMS_PAYLOAD,
+        "items": [{"item": BASE_ALBUM, "type": "album"}],
+    }
+    with pytest.raises(ValidationError):
+        FavoriteAlbumsItems.model_validate(payload)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -2,6 +2,7 @@ import os
 import typer
 import asyncio
 
+from datetime import datetime
 from pathlib import Path
 from logging import getLogger
 from rich.live import Live
@@ -35,6 +36,25 @@ download_command = typer.Typer(name="download")
 register_subcommands(download_command)
 
 log = getLogger(__name__)
+
+
+def _apply_mtime(
+    path: Path,
+    update_mtime: bool,
+    fav_mtime: bool,
+    fav_date_added: str | None,
+) -> None:
+    if update_mtime:
+        try:
+            os.utime(path, None)
+        except Exception:
+            log.warning(f"could not update mtime for {path}")
+    elif fav_mtime and fav_date_added:
+        try:
+            ts = datetime.fromisoformat(fav_date_added).timestamp()
+            os.utime(path, (ts, ts))
+        except Exception:
+            log.warning(f"could not set fav mtime for {path}")
 
 
 @download_command.callback(no_args_is_help=True)
@@ -240,6 +260,7 @@ def download_callback(
                 item: Track | Video,
                 file_path: str,
                 track_metadata: Metadata | None = None,
+                fav_date_added: str | None = None,
             ) -> tuple[Path | None, Track | Video]:
                 log.debug(f"{item.id=}, {file_path=}")
                 rich_output.total_increment()
@@ -300,15 +321,17 @@ def download_callback(
                     elif isinstance(item, Video):
                         add_video_metadata(path=download_path, video=item)
 
-                if download_path and CONFIG.download.update_mtime:
-                    try:
-                        os.utime(download_path, None)
-                    except Exception:
-                        log.warning(f"could not update mtime for {download_path}")
+                if download_path:
+                    _apply_mtime(
+                        download_path,
+                        update_mtime=CONFIG.download.update_mtime,
+                        fav_mtime=CONFIG.download.fav_mtime,
+                        fav_date_added=fav_date_added,
+                    )
 
                 return download_path, item
 
-            async def download_album(album: Album):
+            async def download_album(album: Album, fav_date_added: str | None = None):
                 offset = 0
                 futures = []
 
@@ -364,6 +387,7 @@ def download_callback(
                                         credits=album_item.credits,
                                         album_review=album_review,
                                     ),
+                                    fav_date_added=fav_date_added,
                                 )
                             )
                         except ApiError as e:
@@ -437,6 +461,7 @@ def download_callback(
                             artist=album.artist.name if album.artist else "",
                             # credits are missing
                         ),
+                        fav_date_added=resource.fav_date_added,
                     )
 
                     if (
@@ -474,6 +499,7 @@ def download_callback(
                             album=album,
                             quality=get_item_quality(video),
                         ),
+                        fav_date_added=resource.fav_date_added,
                     )
 
                 case "mix":
@@ -541,7 +567,7 @@ def download_callback(
 
                 case "album":
                     album = ctx.obj.api.get_album(album_id=resource.id)
-                    await download_album(album)
+                    await download_album(album, fav_date_added=resource.fav_date_added)
 
                 case "artist":
                     futures = []

--- a/tiddl/cli/commands/subcommands/fav.py
+++ b/tiddl/cli/commands/subcommands/fav.py
@@ -2,6 +2,7 @@ import typer
 from typing import cast
 from typing_extensions import Annotated
 
+from tiddl.cli.config import CONFIG
 from tiddl.cli.ctx import Context
 from tiddl.cli.utils.resource import ResourceTypeLiteral, TidalResource
 
@@ -32,12 +33,34 @@ def fav(
     stats: dict[ResourceTypeLiteral, int] = dict()
 
     for resource_type in cast(list[ResourceTypeLiteral], TYPES):
-        resources = favorites_dict[resource_type.upper()]
-
-        stats[resource_type] = len(resources)
-
-        for resource_id in resources:
-            ctx.obj.resources.append(TidalResource(id=resource_id, type=resource_type))
+        if CONFIG.download.fav_mtime and resource_type in ("track", "video", "album"):
+            offset = 0
+            count = 0
+            while True:
+                if resource_type == "track":
+                    page = ctx.obj.api.get_favorite_tracks(offset=offset)
+                elif resource_type == "video":
+                    page = ctx.obj.api.get_favorite_videos(offset=offset)
+                else:
+                    page = ctx.obj.api.get_favorite_albums(offset=offset)
+                for entry in page.items:
+                    ctx.obj.resources.append(
+                        TidalResource(
+                            id=str(entry.item.id),
+                            type=resource_type,
+                            fav_date_added=entry.created,
+                        )
+                    )
+                    count += 1
+                offset += page.limit
+                if offset >= page.totalNumberOfItems:
+                    break
+            stats[resource_type] = count
+        else:
+            resources = favorites_dict[resource_type.upper()]
+            stats[resource_type] = len(resources)
+            for resource_id in resources:
+                ctx.obj.resources.append(TidalResource(id=resource_id, type=resource_type))
 
     ctx.obj.console.print(f"[green]Loaded {len(ctx.obj.resources)} resources")
 

--- a/tiddl/cli/config.py
+++ b/tiddl/cli/config.py
@@ -55,6 +55,7 @@ class Config(BaseModel):
         singles_filter: ARTIST_SINGLES_FILTER_LITERAL = "none"
         videos_filter: VIDEOS_FILTER_LITERAL = "none"
         update_mtime: bool = False
+        fav_mtime: bool = False
         rewrite_metadata: bool = False
         write_lrc_file: bool = False
         match_existing_path_case: bool = False

--- a/tiddl/cli/utils/resource.py
+++ b/tiddl/cli/utils/resource.py
@@ -10,6 +10,7 @@ ResourceTypeLiteral = Literal["track", "video", "album", "playlist", "artist", "
 class TidalResource(BaseModel):
     type: ResourceTypeLiteral
     id: str
+    fav_date_added: str | None = None
 
     @property
     def url(self) -> str:

--- a/tiddl/core/api/api.py
+++ b/tiddl/core/api/api.py
@@ -8,6 +8,9 @@ from .models.base import (
     AlbumItemsCredits,
     ArtistAlbumsItems,
     ArtistVideosItems,
+    FavoriteAlbumsItems,
+    FavoriteTracksItems,
+    FavoriteVideosItems,
     Favorites,
     MixItems,
     PlaylistItems,
@@ -48,6 +51,15 @@ class Limits:
 
     MIX_ITEMS = 20
     MIX_ITEMS_MAX = 100
+
+    FAVORITE_ALBUMS = 20
+    FAVORITE_ALBUMS_MAX = 100
+
+    FAVORITE_TRACKS = 20
+    FAVORITE_TRACKS_MAX = 100
+
+    FAVORITE_VIDEOS = 20
+    FAVORITE_VIDEOS_MAX = 100
 
 
 class TidalAPI:
@@ -170,6 +182,48 @@ class TidalAPI:
             Favorites,
             f"users/{self.user_id}/favorites/ids",
             {"countryCode": self.country_code},
+            expire_after=EXPIRE_IMMEDIATELY,
+        )
+
+    def get_favorite_albums(
+        self, limit: int = Limits.FAVORITE_ALBUMS, offset: int = 0
+    ):
+        return self.client.fetch(
+            FavoriteAlbumsItems,
+            f"users/{self.user_id}/favorites/albums",
+            {
+                "countryCode": self.country_code,
+                "limit": min(limit, Limits.FAVORITE_ALBUMS_MAX),
+                "offset": offset,
+            },
+            expire_after=EXPIRE_IMMEDIATELY,
+        )
+
+    def get_favorite_tracks(
+        self, limit: int = Limits.FAVORITE_TRACKS, offset: int = 0
+    ):
+        return self.client.fetch(
+            FavoriteTracksItems,
+            f"users/{self.user_id}/favorites/tracks",
+            {
+                "countryCode": self.country_code,
+                "limit": min(limit, Limits.FAVORITE_TRACKS_MAX),
+                "offset": offset,
+            },
+            expire_after=EXPIRE_IMMEDIATELY,
+        )
+
+    def get_favorite_videos(
+        self, limit: int = Limits.FAVORITE_VIDEOS, offset: int = 0
+    ):
+        return self.client.fetch(
+            FavoriteVideosItems,
+            f"users/{self.user_id}/favorites/videos",
+            {
+                "countryCode": self.country_code,
+                "limit": min(limit, Limits.FAVORITE_VIDEOS_MAX),
+                "offset": offset,
+            },
             expire_after=EXPIRE_IMMEDIATELY,
         )
 

--- a/tiddl/core/api/models/base.py
+++ b/tiddl/core/api/models/base.py
@@ -121,6 +121,33 @@ class Favorites(BaseModel):
     ARTIST: List[str]
 
 
+class FavoriteAlbumsItems(Items):
+    class FavoriteAlbumItem(BaseModel):
+        item: Album
+        type: Literal["album"] = "album"
+        created: str
+
+    items: List[FavoriteAlbumItem]
+
+
+class FavoriteTracksItems(Items):
+    class FavoriteTrackItem(BaseModel):
+        item: Track
+        type: ItemType = "track"
+        created: str
+
+    items: List[FavoriteTrackItem]
+
+
+class FavoriteVideosItems(Items):
+    class FavoriteVideoItem(BaseModel):
+        item: Video
+        type: ItemType = "video"
+        created: str
+
+    items: List[FavoriteVideoItem]
+
+
 class TrackStream(BaseModel):
     trackId: int
     assetPresentation: Literal["FULL"]


### PR DESCRIPTION
## Summary

- Adds a new `fav_mtime` boolean config option (default `false`) under `[download]`
- When enabled, files downloaded via `tiddl download fav` have their modification time set to the date the item was added to favorites, rather than the current time
- Applies to direct track and video favorites (per-item date) and album favorites (all tracks share the album's favorited date)
- Does not apply to playlist or artist favorites
- When `update_mtime` is also enabled, it takes precedence and the current time is used (existing behaviour unchanged)

## Implementation

- New API methods `get_favorite_tracks()`, `get_favorite_videos()`, `get_favorite_albums()` hitting the paginated `/users/{id}/favorites/{tracks,videos,albums}` endpoints, which return items with a `created` timestamp
- New Pydantic models `FavoriteTracksItems`, `FavoriteVideosItems`, `FavoriteAlbumsItems` following the existing `PlaylistItems` pattern
- `TidalResource` carries an optional `fav_date_added` field set only during fav downloads when `fav_mtime` is on
- Mtime logic extracted into a module-level `_apply_mtime()` helper for testability
- `download_album()` accepts and propagates `fav_date_added` to all its `handle_item` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)