### PR TITLE
Feature add custom formatter for capitalizing the first character in output templates

### DIFF
--- a/tests/core/utils/test_utils_format.py
+++ b/tests/core/utils/test_utils_format.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from tiddl.core.utils.format import AlbumTemplate, format_template, generate_template_data
+from tiddl.core.utils.format import AlbumTemplate, format_template, generate_template_data, TiddlFormatter
 from tiddl.core.api.models.resources import Video
 
 
@@ -101,3 +101,44 @@ class TestGenerateTemplateDataAlbumFallback:
         album = data["album"]
         assert album.title == ""
         assert album.artist == ""
+
+class TestTemplateFormatter:
+    def test_capitalize_lowercase(self):
+        assert TiddlFormatter().format("{0:!c}", "radiohead") == "Radiohead"
+
+    def test_capitalize_already_capitalized(self):
+        assert TiddlFormatter().format("{0:!c}", "Radiohead") == "Radiohead"
+
+    def test_capitalize_single_character(self):
+        assert TiddlFormatter().format("{0:!c}", "r") == "R"
+
+    def test_capitalize_empty_string(self):
+        assert TiddlFormatter().format("{0:!c}", "") == ""
+
+    def test_capitalize_preserves_remaining_characters(self):
+        assert TiddlFormatter().format("{0:!c}", "rADIOHEAD") == "RADIOHEAD"
+
+    def test_capitalize_unicode(self):
+        assert TiddlFormatter().format("{0:!c}", "björk") == "Björk"
+
+    def test_capitalize_numeric_string(self):
+        assert TiddlFormatter().format("{0:!c}", "123abc") == "123abc"
+
+    def test_capitalize_non_string_value(self):
+        assert TiddlFormatter().format("{0:!c}", 123) == "123"
+
+    def test_output_template_with_capitalize_conversion(self):
+        data = generate_template_data(item=BASE_VIDEO, album=None)
+        album = data["album"]
+        album.artist = "radiohead"
+
+        result = TiddlFormatter().format(
+            "{album.artist:!c}/{album.artist}",
+            album=album,
+        )
+
+        assert result == "Radiohead/radiohead"
+
+    def test_standard_python_conversions_unchanged(self):
+        assert TiddlFormatter().format("{0!s}", "radiohead") == "radiohead"
+        assert TiddlFormatter().format("{0!r}", "radiohead") == "'radiohead'"

--- a/tiddl/core/utils/format.py
+++ b/tiddl/core/utils/format.py
@@ -1,4 +1,5 @@
 import re
+import string
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -26,6 +27,13 @@ def _clean_segment(text: str) -> str:
 
     return text or "_"
 
+class TiddlFormatter(string.Formatter):
+    def format_field(self, value, format_spec):
+        if format_spec == "!c":
+            value = str(value)
+            return value[:1].upper() + value[1:]
+
+        return super().format_field(value, format_spec)
 
 class Explicit:
     def __init__(self, value: bool | None):
@@ -223,7 +231,8 @@ def format_template(
     segments: list[str] = []
 
     for raw_segment in template.split("/"):
-        formatted = raw_segment.format(**data)
+        formatter = TiddlFormatter()
+        formatted = formatter.format(raw_segment,**data)
         cleaned = _clean_segment(formatted)
         segments.append(cleaned)
 


### PR DESCRIPTION
### Summary

This PR adds a custom !c conversion specifier to tiddl's template formatter.

The new conversion allows users to capitalize the first character of a string directly in output path templates without modifying source metadata.

### Example

Template:

{album.artist!c}/{album.artist}/{album.date:%Y} {album.title}/{item.number:02d} {item.title_version}

Output:

Radiohead/radiohead/1997 OK Computer/01 Airbag

### Motivation

Currently, output templates support field access and standard Python formatting, but there is no simple way to perform basic string transformations such as capitalizing the first character of an artist name.

It solves an issue when a music library structure looks like this:
- A
  - Artist A1
    - Album A1
  - Artist A2
- B
  - Artist B1
    - Album B1
- b
  - Artist b2
    - Album b2
- ...

I noticed some artists name start with a lower case, thus creating a second folder with the lower case like in the example above. 
Maybe there's a simpler way to only have one folder with all artists starting with the same letter ignoring the case ?
Using str.upper() in the template is not working.

### Future Possibilities

This approach could be extended later with additional string conversions if there is demand.