### PR TITLE
metadata: not sort artists alphabetically on track metadata

### DIFF
--- a/tiddl/core/metadata/track.py
+++ b/tiddl/core/metadata/track.py
@@ -189,7 +189,7 @@ def add_track_metadata(
         disc_number=str(track.volumeNumber),
         copyright=track.copyright,
         album_artist=album_artist,
-        artists=sorted(a.name.strip() for a in track.artists),
+        artists=[a.name.strip() for a in track.artists],
         album_title=track.album.title,
         date=date,
         isrc=track.isrc,


### PR DESCRIPTION
Ordering in multiple artists tends to matter, since the first listed artist is often the main one. Some examples of this are: https://tidal.com/track/100480229/u and https://tidal.com/track/235190187/u