### PR TITLE
Fix mutagen FLACNoHeaderError by handling DASH containers and AAC dow…

### DIFF
--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -171,8 +171,7 @@ class Downloader:
                     )
                     return None, False
 
-                urls, _ = parse_track_stream(stream)
-                download_path = self.get_path(self.download_path, filename)
+                urls, stream_ext = parse_track_stream(stream)
 
                 quality_string = track_qualities_color[stream.audioQuality]
 
@@ -181,12 +180,17 @@ class Downloader:
                     and stream.audioMode == "STEREO"
                 ):
                     quality_string = f"{quality_string} {stream.bitDepth}-bit, {(stream.sampleRate or 0) / 1000:.1f} kHz"
-                    should_extract_flac = True
+                    filename = filename.with_suffix(".flac")
+                    if stream_ext == ".m4a" or stream.manifestMimeType == "application/dash+xml" or stream.audioQuality == "HI_RES_LOSSLESS":
+                        should_extract_flac = True
                 else:
-                    download_path = download_path.with_suffix(".m4a")
+                    filename = filename.with_suffix(".m4a")
+                    should_extract_flac = False
 
                     if stream.audioMode == "DOLBY_ATMOS":
                         quality_string = "[blue]Dolby Atmos[/]"
+
+                download_path = self.get_path(self.download_path, filename)
 
             elif isinstance(item, Video):
                 stream = self.api.get_video_stream(

--- a/tiddl/core/utils/parse.py
+++ b/tiddl/core/utils/parse.py
@@ -80,12 +80,12 @@ def parse_track_stream(track_stream: TrackStream) -> tuple[list[str], str]:
 
     if codecs == "flac":
         file_extension = ".flac"
-        if track_stream.audioQuality == "HI_RES_LOSSLESS":
+        if track_stream.audioQuality == "HI_RES_LOSSLESS" or track_stream.manifestMimeType == "application/dash+xml":
             file_extension = ".m4a"
     elif codecs.startswith("mp4") or codecs in DOLBY_CODECS:
         file_extension = ".m4a"
     else:
-        raise ValueError(f"Unknown codecs `{codecs}` (trackId {track_stream.trackId}")
+        raise ValueError(f"Unknown codecs `{codecs}` (trackId {track_stream.trackId})")
 
     return urls, file_extension
 


### PR DESCRIPTION
This PR fixes a bug where `mutagen` would crash with `FLACNoHeaderError: ... is not a valid FLAC file` when downloading tracks.

**Issue:**
When a track stream is delivered in a DASH container (`application/dash+xml`), the raw downloaded file is an MP4/M4A container. Previously, `tiddl` assumed that only `HI_RES_LOSSLESS` used an `.m4a` container. For regular `LOSSLESS` tracks served via DASH, or when an AAC stream was provided instead of a lossless one (e.g. 320 kbps downgrade), it saved the MP4/AAC stream directly with a `.flac` extension. This caused `MutagenFLAC` to crash.

**Fix:**
* Updated `parse_track_stream` to properly return the `.m4a` extension for all DASH manifests. 
* `Downloader.download` now dynamically checks if the stream is in an `.m4a` container (either via DASH manifest or `stream_ext`) and correctly sets `should_extract_flac = True` to extract the FLAC audio out of the MP4 container using `ffmpeg`. 
* It also dynamically corrects the file extension to `.m4a` when downloading non-lossless (AAC) streams.