### PR TITLE
Enable MAX Hi-Res and Dolby Atmos from one login

### DIFF
--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -91,11 +91,10 @@ write_lrc_file = false
 # downloads will continue under "FooBar".
 match_existing_path_case = false
 
-# Dolby Atmos filter
-# none - download only STEREO tracks
-# only - download only DOLBY_ATMOS tracks
-# allow - download both
-# (both versions won't be downloaded at a time, it depends on what Tidal returns)
+# Dolby Atmos handling
+# none - use STEREO
+# only - use DOLBY_ATMOS
+# allow - prefer DOLBY_ATMOS when available, otherwise use STEREO
 atmos_filter = "none"
 
 

--- a/tests/cli/commands/auth/test_auth.py
+++ b/tests/cli/commands/auth/test_auth.py
@@ -230,6 +230,8 @@ def test_refresh_success(monkeypatch: pytest.MonkeyPatch):
 
     mock_auth_response = MagicMock()
     mock_auth_response.access_token = "newtoken"
+    mock_auth_response.expires_in = 3600
+    mock_auth_response.refresh_token = None
 
     with (
         patch("tiddl.cli.commands.auth.AuthAPI") as MockAuthAPI,
@@ -241,5 +243,32 @@ def test_refresh_success(monkeypatch: pytest.MonkeyPatch):
         result = runner.invoke(auth_command, ["refresh"])
 
         mock_save.assert_called_once_with(expired_data)
+        assert expired_data.token == "newtoken"
+        assert expired_data.refresh_token == "refreshtoken"
         assert "Auth token has been refreshed!" in result.stdout
         assert result.exit_code == 0
+
+
+def test_refresh_saves_rotated_refresh_token(monkeypatch: pytest.MonkeyPatch):
+    expired_data = AuthData(
+        token="oldtoken", refresh_token="old-refresh-token", expires_at=0
+    )
+    monkeypatch.setattr("tiddl.cli.commands.auth.load_auth_data", lambda: expired_data)
+
+    mock_auth_response = MagicMock(
+        access_token="newtoken",
+        expires_in=3600,
+        refresh_token="rotated-refresh-token",
+    )
+
+    with (
+        patch("tiddl.cli.commands.auth.AuthAPI") as MockAuthAPI,
+        patch("tiddl.cli.commands.auth.save_auth_data") as mock_save,
+    ):
+        MockAuthAPI.return_value.refresh_token.return_value = mock_auth_response
+
+        result = runner.invoke(auth_command, ["refresh"])
+
+        assert result.exit_code == 0
+        assert expired_data.refresh_token == "rotated-refresh-token"
+        mock_save.assert_called_once_with(expired_data)

--- a/tests/cli/commands/test_downloader.py
+++ b/tests/cli/commands/test_downloader.py
@@ -1,0 +1,105 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from tiddl.cli.commands.download.downloader import Downloader
+from tiddl.core.api.models import Track
+
+
+@pytest.mark.parametrize(
+    ("atmos_filter", "audio_modes", "tags", "expected_profile"),
+    [
+        ("none", ["DOLBY_ATMOS"], ["HIRES_LOSSLESS"], "hires"),
+        ("only", ["STEREO"], ["LOSSLESS"], "atmos"),
+        ("allow", ["STEREO"], ["DOLBY_ATMOS"], "atmos"),
+        ("allow", ["STEREO"], ["HIRES_LOSSLESS"], "hires"),
+    ],
+)
+def test_get_track_api_selects_capability_profile(
+    mocker: MockerFixture,
+    tmp_path,
+    atmos_filter,
+    audio_modes,
+    tags,
+    expected_profile,
+):
+    catalog_api = mocker.Mock()
+    playback_api = mocker.Mock()
+    get_playback_api = mocker.Mock(return_value=playback_api)
+    downloader = Downloader(
+        tidal_api=catalog_api,
+        threads_count=1,
+        rich_output=mocker.Mock(),
+        track_quality="max",
+        video_quality="fhd",
+        videos_filter="allow",
+        skip_existing=True,
+        download_path=tmp_path,
+        scan_path=tmp_path,
+        dolby_atmos_filter=atmos_filter,
+        get_playback_api=get_playback_api,
+    )
+    track = mocker.Mock(
+        audioModes=audio_modes,
+        mediaMetadata=mocker.Mock(tags=tags),
+    )
+
+    assert downloader.get_track_api(track) is playback_api
+    get_playback_api.assert_called_once_with(expected_profile)
+
+
+def test_get_track_api_preserves_legacy_api(mocker: MockerFixture, tmp_path):
+    catalog_api = mocker.Mock()
+    downloader = Downloader(
+        tidal_api=catalog_api,
+        threads_count=1,
+        rich_output=mocker.Mock(),
+        track_quality="max",
+        video_quality="fhd",
+        videos_filter="allow",
+        skip_existing=True,
+        download_path=tmp_path,
+        scan_path=tmp_path,
+    )
+
+    assert downloader.get_track_api(mocker.Mock()) is catalog_api
+
+
+def test_atmos_download_checks_m4a_instead_of_existing_max_flac(
+    mocker: MockerFixture,
+    tmp_path,
+):
+    get_playback_api = mocker.Mock()
+    downloader = Downloader(
+        tidal_api=mocker.Mock(),
+        threads_count=1,
+        rich_output=mocker.Mock(),
+        track_quality="max",
+        video_quality="fhd",
+        videos_filter="allow",
+        skip_existing=True,
+        download_path=tmp_path,
+        scan_path=tmp_path,
+        dolby_atmos_filter="only",
+        get_playback_api=get_playback_api,
+    )
+    track = mocker.Mock(spec=Track)
+    track.allowStreaming = True
+    track.title = "Track"
+    track.id = 1
+    track.audioQuality = "HI_RES_LOSSLESS"
+    track.audioModes = ["DOLBY_ATMOS"]
+    track.mediaMetadata = mocker.Mock(tags=["HIRES_LOSSLESS", "DOLBY_ATMOS"])
+    track.album = mocker.Mock(vibrantColor=None)
+    file_path = Path("track")
+    (tmp_path / file_path.with_suffix(".flac")).touch()
+    atmos_path = tmp_path / file_path.with_suffix(".m4a")
+    atmos_path.touch()
+
+    item_path, was_downloaded = asyncio.run(downloader.download(track, file_path))
+
+    assert item_path == atmos_path
+    assert not was_downloaded
+    get_playback_api.assert_not_called()

--- a/tests/cli/test_ctx.py
+++ b/tests/cli/test_ctx.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+from rich.console import Console
+
+from tiddl.cli.ctx import ContextObject
+from tiddl.cli.utils.auth.models import AuthData
+from tiddl.core.auth.profiles import ProfileToken
+
+
+def test_playback_api_uses_derived_token_and_persists_rotation(
+    mocker: MockerFixture,
+):
+    initial_auth_data = AuthData(
+        token="catalog-token",
+        refresh_token="refresh-token",
+        expires_at=3600,
+        user_id="1",
+        country_code="US",
+    )
+    latest_auth_data = initial_auth_data.model_copy()
+    mocker.patch(
+        "tiddl.cli.ctx.load_auth_data",
+        side_effect=[initial_auth_data, latest_auth_data],
+    )
+    save_auth_data = mocker.patch("tiddl.cli.ctx.save_auth_data")
+
+    token_manager = mocker.Mock()
+    token_manager.get_token.return_value = ProfileToken(
+        access_token="profile-access-token",
+        client_id="profile-client-id",
+        expires_at=3600,
+    )
+    token_manager_class = mocker.patch(
+        "tiddl.cli.ctx.ProfileTokenManager", return_value=token_manager
+    )
+    tidal_client = mocker.Mock()
+    tidal_client_class = mocker.patch(
+        "tiddl.cli.ctx.TidalClient", return_value=tidal_client
+    )
+
+    context = ContextObject(
+        api_omit_cache=True,
+        debug_path=Path("/tmp/debug"),
+        console=Console(),
+    )
+    api = context.get_playback_api("hires")
+
+    assert api.client is tidal_client
+    token_manager.get_token.assert_called_once_with("hires")
+    tidal_client_class.assert_called_once_with(
+        token="profile-access-token",
+        client_id="profile-client-id",
+        cache_name=mocker.ANY,
+        omit_cache=True,
+        debug_path=Path("/tmp/debug"),
+        on_token_expiry=mocker.ANY,
+    )
+
+    on_refresh_token = token_manager_class.call_args.kwargs["on_refresh_token"]
+    on_refresh_token("rotated-refresh-token")
+
+    assert latest_auth_data.refresh_token == "rotated-refresh-token"
+    save_auth_data.assert_called_once_with(auth_data=latest_auth_data)
+
+
+def test_playback_api_reuses_api_and_updates_its_access_token(
+    mocker: MockerFixture,
+):
+    auth_data = AuthData(
+        refresh_token="refresh-token",
+        user_id="1",
+        country_code="US",
+    )
+    load_auth_data = mocker.patch(
+        "tiddl.cli.ctx.load_auth_data", return_value=auth_data
+    )
+    token_manager = mocker.Mock()
+    token_manager.get_token.side_effect = [
+        ProfileToken("first-token", "client-id", 3600),
+        ProfileToken("second-token", "client-id", 7200),
+    ]
+    mocker.patch("tiddl.cli.ctx.ProfileTokenManager", return_value=token_manager)
+    tidal_client = mocker.Mock()
+    tidal_client_class = mocker.patch(
+        "tiddl.cli.ctx.TidalClient", return_value=tidal_client
+    )
+    context = ContextObject(False, None, Console())
+
+    first = context.get_playback_api("atmos")
+    second = context.get_playback_api("atmos")
+
+    assert first is second
+    assert tidal_client.token == "second-token"
+    tidal_client_class.assert_called_once()
+    load_auth_data.assert_called_once()
+
+
+def test_catalog_refresh_keeps_profile_manager_synchronized(
+    mocker: MockerFixture,
+):
+    initial_auth_data = AuthData(
+        token="expired-token",
+        refresh_token="original-refresh-token",
+        user_id="1",
+        country_code="US",
+    )
+    latest_auth_data = initial_auth_data.model_copy()
+    mocker.patch(
+        "tiddl.cli.ctx.load_auth_data",
+        side_effect=[initial_auth_data, latest_auth_data],
+    )
+    mocker.patch("tiddl.cli.ctx.time", return_value=1000)
+    save_auth_data = mocker.patch("tiddl.cli.ctx.save_auth_data")
+    tidal_client_class = mocker.patch("tiddl.cli.ctx.TidalClient")
+    token_manager = mocker.Mock()
+    context = ContextObject(False, None, Console())
+    context._profile_token_manager = token_manager
+    context.auth_api.refresh_token = mocker.Mock(
+        return_value=mocker.Mock(
+            access_token="new-access-token",
+            expires_in=3600,
+            refresh_token="rotated-refresh-token",
+        )
+    )
+
+    _ = context.api
+    on_token_expiry = tidal_client_class.call_args.kwargs["on_token_expiry"]
+
+    assert on_token_expiry() == "new-access-token"
+    token_manager.replace_refresh_token.assert_called_once_with("rotated-refresh-token")
+    assert latest_auth_data.token == "new-access-token"
+    assert latest_auth_data.expires_at == 4600
+    assert latest_auth_data.refresh_token == "rotated-refresh-token"
+    save_auth_data.assert_called_once_with(auth_data=latest_auth_data)

--- a/tests/core/api/test_api_client.py
+++ b/tests/core/api/test_api_client.py
@@ -28,6 +28,19 @@ def test_tidal_client_init(mocker: MockerFixture):
     assert client.session is mock_session
     assert mock_session.headers["Authorization"] == "Bearer test-token"
     assert mock_session.headers["Accept"] == "application/json"
+    assert "X-Tidal-Token" not in mock_session.headers
+
+
+def test_tidal_client_sets_client_profile_header(mocker: MockerFixture):
+    mock_session = mocker.patch("tiddl.core.api.client.CachedSession").return_value
+
+    TidalClient(
+        token="test-token",
+        cache_name="test_cache",
+        client_id="client-id",
+    )
+
+    assert mock_session.headers["X-Tidal-Token"] == "client-id"
 
 
 @pytest.mark.parametrize("omit_cache", [True, False])

--- a/tests/core/auth/test_auth_api.py
+++ b/tests/core/auth/test_auth_api.py
@@ -4,8 +4,8 @@ from pytest_mock import MockerFixture
 from tiddl.core.auth.api import AuthAPI
 from tiddl.core.auth.models import (
     AuthDeviceResponse,
+    AuthRefreshResponse,
     AuthResponseWithRefresh,
-    AuthResponse,
 )
 
 
@@ -91,11 +91,12 @@ def test_get_auth_returns_model(mock_auth_client: Any) -> None:
 
 def test_refresh_token_returns_model(mock_auth_client: Any) -> None:
     api: AuthAPI = AuthAPI(client=mock_auth_client)
-    result: AuthResponse = api.refresh_token("refresh123")
+    result: AuthRefreshResponse = api.refresh_token("refresh123")
 
     mock_auth_client.refresh_token.assert_called_once_with("refresh123")
-    assert isinstance(result, AuthResponse)
+    assert isinstance(result, AuthRefreshResponse)
     assert result.access_token == "token123"
+    assert result.refresh_token == "refresh123"
 
 
 def test_logout_token_calls_client(mock_auth_client: Any) -> None:

--- a/tests/core/auth/test_auth_client.py
+++ b/tests/core/auth/test_auth_client.py
@@ -115,6 +115,35 @@ def test_refresh_token(mocker: MockerFixture):
     assert result["token"] == "abc"
 
 
+def test_refresh_token_supports_form_client_secret_and_custom_scope(
+    mocker: MockerFixture,
+):
+    mock_request = mocker.patch("tiddl.core.auth.client.request")
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"access_token": "abc"}
+    mock_request.return_value = mock_response
+
+    client = AuthClient(
+        client_id="client-id",
+        client_secret="client-secret",
+        refresh_with_basic_auth=False,
+        refresh_scope="r_usr+w_usr",
+    )
+    client.refresh_token("refresh-token")
+
+    mock_request.assert_called_once_with(
+        "POST",
+        "https://auth.tidal.com/v1/oauth2/token",
+        data={
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "refresh_token": "refresh-token",
+            "grant_type": "refresh_token",
+            "scope": "r_usr+w_usr",
+        },
+    )
+
+
 def test_logout_token(mocker: MockerFixture):
     mock_request = mocker.patch("tiddl.core.auth.client.request")
 

--- a/tests/core/auth/test_auth_profiles.py
+++ b/tests/core/auth/test_auth_profiles.py
@@ -1,0 +1,178 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from tiddl.core.auth.client import CLIENT_ID, CLIENT_SECRET
+from tiddl.core.auth.profiles import (
+    CLIENT_PROFILES,
+    ClientProfile,
+    ProfileTokenManager,
+    select_playback_profile,
+)
+
+
+def test_atmos_profile_uses_configured_auth_credentials():
+    assert CLIENT_PROFILES["atmos"].client_id == CLIENT_ID
+    assert CLIENT_PROFILES["atmos"].client_secret == CLIENT_SECRET
+
+
+@pytest.mark.parametrize(
+    ("atmos_filter", "atmos_available", "expected"),
+    [
+        ("none", True, "hires"),
+        ("only", False, "atmos"),
+        ("allow", True, "atmos"),
+        ("allow", False, "hires"),
+    ],
+)
+def test_select_playback_profile(atmos_filter, atmos_available, expected):
+    assert select_playback_profile(atmos_filter, atmos_available) == expected
+
+
+@pytest.mark.parametrize("profile_name", ["hires", "atmos"])
+def test_manager_builds_auth_client_for_profile(mocker: MockerFixture, profile_name):
+    auth_client_class = mocker.patch("tiddl.core.auth.profiles.AuthClient")
+    auth_client_class.return_value.refresh_token.return_value = {
+        "access_token": "access-token",
+        "expires_in": 3600,
+    }
+
+    ProfileTokenManager("refresh-token").get_token(profile_name)
+
+    profile = CLIENT_PROFILES[profile_name]
+    auth_client_class.assert_called_once_with(
+        client_id=profile.client_id,
+        client_secret=profile.client_secret,
+        refresh_with_basic_auth=profile.refresh_with_basic_auth,
+        refresh_scope="r_usr+w_usr",
+    )
+
+
+def test_profiles_use_one_refresh_token(mocker: MockerFixture):
+    refresh_calls: list[tuple[str, str]] = []
+
+    def client_factory(profile: ClientProfile):
+        client = mocker.Mock()
+
+        def refresh_token(refresh_token: str):
+            refresh_calls.append((profile.client_id, refresh_token))
+            return {
+                "access_token": f"access-{profile.client_id}",
+                "expires_in": 3600,
+            }
+
+        client.refresh_token.side_effect = refresh_token
+        return client
+
+    manager = ProfileTokenManager(
+        refresh_token="one-refresh-token",
+        client_factory=client_factory,
+    )
+
+    hires = manager.get_token("hires")
+    atmos = manager.get_token("atmos")
+
+    assert hires.client_id == CLIENT_PROFILES["hires"].client_id
+    assert atmos.client_id == CLIENT_PROFILES["atmos"].client_id
+    assert refresh_calls == [
+        (CLIENT_PROFILES["hires"].client_id, "one-refresh-token"),
+        (CLIENT_PROFILES["atmos"].client_id, "one-refresh-token"),
+    ]
+
+
+def test_profile_tokens_are_cached_until_the_expiry_margin(
+    mocker: MockerFixture,
+):
+    now = [0.0]
+    client = mocker.Mock()
+    client.refresh_token.side_effect = [
+        {"access_token": "first", "expires_in": 100},
+        {"access_token": "second", "expires_in": 100},
+    ]
+    factory = mocker.Mock(return_value=client)
+    manager = ProfileTokenManager(
+        refresh_token="refresh-token",
+        clock=lambda: now[0],
+        expiry_margin=10,
+        client_factory=factory,
+    )
+
+    first = manager.get_token("hires")
+    now[0] = 89
+    cached = manager.get_token("hires")
+    now[0] = 90
+    refreshed = manager.get_token("hires")
+
+    assert first is cached
+    assert refreshed.access_token == "second"
+    assert client.refresh_token.call_count == 2
+
+
+def test_profile_token_can_be_force_refreshed(mocker: MockerFixture):
+    client = mocker.Mock()
+    client.refresh_token.side_effect = [
+        {"access_token": "first", "expires_in": 3600},
+        {"access_token": "second", "expires_in": 3600},
+    ]
+    manager = ProfileTokenManager(
+        refresh_token="refresh-token",
+        client_factory=mocker.Mock(return_value=client),
+    )
+
+    manager.get_token("atmos")
+    refreshed = manager.get_token("atmos", force=True)
+
+    assert refreshed.access_token == "second"
+    assert client.refresh_token.call_count == 2
+
+
+def test_rotated_refresh_token_is_saved_and_reused(mocker: MockerFixture):
+    refresh_calls: list[str] = []
+    on_refresh_token = mocker.Mock()
+
+    def client_factory(profile: ClientProfile):
+        client = mocker.Mock()
+
+        def refresh_token(refresh_token: str):
+            refresh_calls.append(refresh_token)
+            response = {
+                "access_token": f"access-{profile.client_id}",
+                "expires_in": 3600,
+            }
+            if len(refresh_calls) == 1:
+                response["refresh_token"] = "rotated-refresh-token"
+            return response
+
+        client.refresh_token.side_effect = refresh_token
+        return client
+
+    manager = ProfileTokenManager(
+        refresh_token="original-refresh-token",
+        on_refresh_token=on_refresh_token,
+        client_factory=client_factory,
+    )
+
+    manager.get_token("hires")
+    manager.get_token("atmos")
+
+    assert refresh_calls == [
+        "original-refresh-token",
+        "rotated-refresh-token",
+    ]
+    on_refresh_token.assert_called_once_with("rotated-refresh-token")
+
+
+def test_replace_refresh_token_uses_external_rotation(mocker: MockerFixture):
+    client = mocker.Mock()
+    client.refresh_token.return_value = {
+        "access_token": "access-token",
+        "expires_in": 3600,
+    }
+    manager = ProfileTokenManager(
+        refresh_token="original-refresh-token",
+        client_factory=mocker.Mock(return_value=client),
+    )
+
+    manager.replace_refresh_token("external-refresh-token")
+    manager.get_token("hires")
+
+    client.refresh_token.assert_called_once_with("external-refresh-token")

--- a/tiddl/cli/commands/auth.py
+++ b/tiddl/cli/commands/auth.py
@@ -155,6 +155,8 @@ def refresh(
 
     loaded_auth_data.token = auth_data.access_token
     loaded_auth_data.expires_at = auth_data.expires_in + int(time())
+    if auth_data.refresh_token:
+        loaded_auth_data.refresh_token = auth_data.refresh_token
 
     save_auth_data(loaded_auth_data)
 

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -132,7 +132,7 @@ def download_callback(
         typer.Option(
             "--dolby-atmos",
             "-da",
-            help="Dolby Atmos filter, 'none' to exclude, 'allow' to include, 'only' to download only Dolby Atmos, if available.",
+            help="Dolby Atmos handling: 'none' uses stereo, 'allow' prefers Atmos when available, 'only' uses Atmos.",
         ),
     ] = CONFIG.download.atmos_filter,
 ):
@@ -218,6 +218,7 @@ def download_callback(
             scan_path=SCAN_PATH,
             match_existing_path_case=CONFIG.download.match_existing_path_case,
             dolby_atmos_filter=DOLBY_ATMOS_FILTER,
+            get_playback_api=ctx.obj.get_playback_api,
         )
 
         class Metadata:

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -1,5 +1,6 @@
 import asyncio
 import shutil
+from collections.abc import Callable
 from logging import getLogger
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -7,11 +8,12 @@ from tempfile import NamedTemporaryFile
 import aiofiles
 import aiohttp
 
-from tiddl.cli.config import VIDEOS_FILTER_LITERAL, ATMOS_FILTER_LITERAL
+from tiddl.cli.config import ATMOS_FILTER_LITERAL, VIDEOS_FILTER_LITERAL
 from tiddl.cli.utils.download import get_existing_track_filename
 from tiddl.cli.utils.path import resolve_existing_path_case
 from tiddl.core.api import ApiError, TidalAPI
 from tiddl.core.api.models import StreamVideoQuality, Track, TrackQuality, Video
+from tiddl.core.auth import PlaybackProfile, select_playback_profile
 from tiddl.core.utils import parse_track_stream, parse_video_stream
 from tiddl.core.utils.const import (
     TRACK_QUALITY_LITERAL,
@@ -53,6 +55,7 @@ class Downloader:
     scan_path: Path
     match_existing_path_case: bool
     dolby_atmos_filter: ATMOS_FILTER_LITERAL
+    get_playback_api: Callable[[PlaybackProfile], TidalAPI] | None
 
     def __init__(
         self,
@@ -67,6 +70,7 @@ class Downloader:
         scan_path: Path,
         match_existing_path_case: bool = False,
         dolby_atmos_filter: ATMOS_FILTER_LITERAL = "none",
+        get_playback_api: Callable[[PlaybackProfile], TidalAPI] | None = None,
     ) -> None:
         self.api = tidal_api
         self.rich_output = rich_output
@@ -79,6 +83,32 @@ class Downloader:
         self.scan_path = scan_path
         self.match_existing_path_case = match_existing_path_case
         self.dolby_atmos_filter = dolby_atmos_filter
+        self.get_playback_api = get_playback_api
+
+    def get_track_profile(self, track: Track) -> PlaybackProfile | None:
+        if not self.get_playback_api:
+            return None
+
+        atmos_available = (
+            "DOLBY_ATMOS" in track.audioModes
+            or "DOLBY_ATMOS" in track.mediaMetadata.tags
+        )
+        return select_playback_profile(
+            self.dolby_atmos_filter,
+            atmos_available,
+        )
+
+    def get_track_api(
+        self,
+        track: Track,
+        profile: PlaybackProfile | None = None,
+    ) -> TidalAPI:
+        if not self.get_playback_api:
+            return self.api
+
+        profile = profile or self.get_track_profile(track)
+        assert profile
+        return self.get_playback_api(profile)
 
     def get_path(self, base_path: Path, relative_path: Path) -> Path:
         if self.match_existing_path_case:
@@ -101,10 +131,18 @@ class Downloader:
             )
             return None, False
 
+        track_profile: PlaybackProfile | None = None
+
         if isinstance(item, Track):
-            filename = get_existing_track_filename(
-                item.audioQuality, self.track_quality, file_path
-            )
+            track_profile = self.get_track_profile(item)
+            if track_profile == "atmos":
+                filename = file_path.with_suffix(".m4a")
+            else:
+                filename = get_existing_track_filename(
+                    item.audioQuality,
+                    self.track_quality,
+                    file_path,
+                )
             existing_file_path = self.get_path(self.scan_path, filename)
             vibrant_color = item.album.vibrantColor
 
@@ -144,7 +182,7 @@ class Downloader:
         async with self.semaphore:
             if isinstance(item, Track):
                 try:
-                    stream = self.api.get_track_stream(
+                    stream = self.get_track_api(item, track_profile).get_track_stream(
                         track_id=item.id, quality=self.track_quality
                     )
 
@@ -160,7 +198,7 @@ class Downloader:
                         and stream.audioMode == "STEREO"
                     ):
                         self.rich_output.console.print(
-                            f"[blue]Skipping[/] [gray]{item.title}[/] [blue]due to Dolby Atmos filter[/] {self.dolby_atmos_filter}"
+                            f"[blue]Skipping[/] [gray]{item.title}[/] [blue]due to Dolby Atmos setting[/] {self.dolby_atmos_filter}"
                         )
                         return None, False
 

--- a/tiddl/cli/ctx.py
+++ b/tiddl/cli/ctx.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from tiddl.core.api import TidalClient, TidalAPI
 from tiddl.cli.config import APP_PATH
-from tiddl.core.auth import AuthAPI
+from tiddl.core.auth import AuthAPI, PlaybackProfile, ProfileTokenManager
 from tiddl.cli.utils.auth.core import load_auth_data, save_auth_data
 from tiddl.cli.utils.resource import TidalResource
 
@@ -16,6 +16,10 @@ class ContextObject:
     resources: list[TidalResource]
     auth_api: AuthAPI
     _api: TidalAPI | None
+    _profile_apis: dict[PlaybackProfile, TidalAPI]
+    _profile_token_manager: ProfileTokenManager | None
+    _playback_user_id: str | None
+    _playback_country_code: str | None
     api_omit_cache: bool
     debug_path: Path | None
 
@@ -26,8 +30,17 @@ class ContextObject:
         self.resources = []
         self.auth_api = AuthAPI()
         self._api = None
+        self._profile_apis = {}
+        self._profile_token_manager = None
+        self._playback_user_id = None
+        self._playback_country_code = None
         self.api_omit_cache = api_omit_cache
         self.debug_path = debug_path
+
+    def _persist_refresh_token(self, refresh_token: str) -> None:
+        auth_data = load_auth_data()
+        auth_data.refresh_token = refresh_token
+        save_auth_data(auth_data=auth_data)
 
     @property
     def api(self):
@@ -40,20 +53,27 @@ class ContextObject:
         assert auth_data.user_id, "User ID is missing. Use `tiddl auth login`"
         assert auth_data.country_code, "Country Code is missing. Use `tiddl auth login`"
 
-        refresh_token = auth_data.refresh_token
-        assert refresh_token, "Refresh Token is missing. Use `tiddl auth login`"
+        assert auth_data.refresh_token, (
+            "Refresh Token is missing. Use `tiddl auth login`"
+        )
 
-        def on_token_expiry() -> str | None:
-            auth_response = self.auth_api.refresh_token(refresh_token)
-            auth_data.token = auth_response.access_token
-            auth_data.expires_at = auth_response.expires_in + int(time())
+        def on_token_expiry() -> str:
+            latest_auth_data = load_auth_data()
+            assert latest_auth_data.refresh_token
+            auth_response = self.auth_api.refresh_token(latest_auth_data.refresh_token)
+            latest_auth_data.token = auth_response.access_token
+            latest_auth_data.expires_at = auth_response.expires_in + int(time())
 
-            save_auth_data(auth_data=auth_data)
+            if auth_response.refresh_token:
+                latest_auth_data.refresh_token = auth_response.refresh_token
+                if self._profile_token_manager:
+                    self._profile_token_manager.replace_refresh_token(
+                        auth_response.refresh_token
+                    )
 
-            if auth_response:
-                return auth_response.access_token
+            save_auth_data(auth_data=latest_auth_data)
 
-            return None
+            return auth_response.access_token
 
         client = TidalClient(
             token=auth_data.token,
@@ -66,6 +86,58 @@ class ContextObject:
         self._api = TidalAPI(client, auth_data.user_id, auth_data.country_code)
 
         return self._api
+
+    def get_playback_api(self, profile: PlaybackProfile) -> TidalAPI:
+        token_manager = self._profile_token_manager
+        if token_manager is None:
+            auth_data = load_auth_data()
+            refresh_token = auth_data.refresh_token
+            assert refresh_token, "Refresh Token is missing. Use `tiddl auth login`"
+            assert auth_data.user_id, "User ID is missing. Use `tiddl auth login`"
+            assert auth_data.country_code, (
+                "Country Code is missing. Use `tiddl auth login`"
+            )
+
+            token_manager = ProfileTokenManager(
+                refresh_token=refresh_token,
+                on_refresh_token=self._persist_refresh_token,
+            )
+            self._profile_token_manager = token_manager
+            self._playback_user_id = auth_data.user_id
+            self._playback_country_code = auth_data.country_code
+
+        profile_token = token_manager.get_token(profile)
+        profile_api = self._profile_apis.get(profile)
+
+        if profile_api is not None:
+            if profile_api.client.token != profile_token.access_token:
+                profile_api.client.token = profile_token.access_token
+            return profile_api
+
+        assert self._playback_user_id
+        assert self._playback_country_code
+
+        def on_token_expiry() -> str:
+            assert self._profile_token_manager
+            return self._profile_token_manager.get_token(
+                profile, force=True
+            ).access_token
+
+        client = TidalClient(
+            token=profile_token.access_token,
+            client_id=profile_token.client_id,
+            cache_name=APP_PATH / f"api_cache_{profile}",
+            omit_cache=self.api_omit_cache,
+            debug_path=self.debug_path,
+            on_token_expiry=on_token_expiry,
+        )
+        profile_api = TidalAPI(
+            client,
+            self._playback_user_id,
+            self._playback_country_code,
+        )
+        self._profile_apis[profile] = profile_api
+        return profile_api
 
 
 class Context(typer.Context):

--- a/tiddl/core/api/client.py
+++ b/tiddl/core/api/client.py
@@ -39,16 +39,21 @@ class TidalClient:
         omit_cache: bool = False,
         debug_path: Path | None = None,
         on_token_expiry: Optional[Callable[[], str | None]] = None,
+        client_id: str | None = None,
     ) -> None:
         self.on_token_expiry = on_token_expiry
         self.debug_path = debug_path
         self.session = CachedSession(
             cache_name=cache_name, always_revalidate=omit_cache
         )
-        self.session.headers = {
+        headers = {
             "Authorization": f"Bearer {token}",
             "Accept": "application/json",
         }
+        if client_id:
+            headers["X-Tidal-Token"] = client_id
+
+        self.session.headers = headers
         self._token = token
 
     @property

--- a/tiddl/core/auth/__init__.py
+++ b/tiddl/core/auth/__init__.py
@@ -1,4 +1,15 @@
 from .api import AuthAPI
 from .exceptions import AuthClientError
+from .profiles import (
+    PlaybackProfile,
+    ProfileTokenManager,
+    select_playback_profile,
+)
 
-__all__ = ["AuthAPI", "AuthClientError"]
+__all__ = [
+    "AuthAPI",
+    "AuthClientError",
+    "PlaybackProfile",
+    "ProfileTokenManager",
+    "select_playback_profile",
+]

--- a/tiddl/core/auth/api.py
+++ b/tiddl/core/auth/api.py
@@ -1,7 +1,7 @@
 from tiddl.core.auth.client import AuthClient
 from tiddl.core.auth.models import (
     AuthDeviceResponse,
-    AuthResponse,
+    AuthRefreshResponse,
     AuthResponseWithRefresh,
 )
 
@@ -18,9 +18,9 @@ class AuthAPI:
         json_data = self._client.get_auth(device_code)
         return AuthResponseWithRefresh.model_validate(json_data)
 
-    def refresh_token(self, refresh_token: str) -> AuthResponse:
+    def refresh_token(self, refresh_token: str) -> AuthRefreshResponse:
         json_data = self._client.refresh_token(refresh_token)
-        return AuthResponse.model_validate(json_data)
+        return AuthRefreshResponse.model_validate(json_data)
 
     def logout_token(self, access_token: str) -> None:
         self._client.logout_token(access_token)

--- a/tiddl/core/auth/client.py
+++ b/tiddl/core/auth/client.py
@@ -9,16 +9,19 @@ from tiddl.core.auth.exceptions import AuthClientError
 log = logging.getLogger("tiddl")
 
 
+DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET = (
+    base64.b64decode(
+        "NE4zbjZRMXg5NUxMNUs3cDtvS09YZkpXMzcxY1g2eGFaMFB5aGdHTkJkTkxsQlpkNEFLS1lvdWdNamlrPQ=="
+    )
+    .decode()
+    .split(";")
+)
+
+
 def get_auth_credentials() -> tuple[str, str]:
     ENV_KEY = "TIDDL_AUTH"
 
-    client_id, client_secret = (
-        base64.b64decode(
-            "NE4zbjZRMXg5NUxMNUs3cDtvS09YZkpXMzcxY1g2eGFaMFB5aGdHTkJkTkxsQlpkNEFLS1lvdWdNamlrPQ=="
-        )
-        .decode()
-        .split(";")
-    )
+    client_id, client_secret = DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET
 
     env_value = environ.get(ENV_KEY, None)
 
@@ -38,10 +41,18 @@ JSON: TypeAlias = dict[str, Any]
 
 class AuthClient:
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        client_id: str = CLIENT_ID,
+        client_secret: str = CLIENT_SECRET,
+        refresh_with_basic_auth: bool = True,
+        refresh_scope: str = "r_usr+w_usr+w_sub",
+    ) -> None:
         self.auth_url = AUTH_URL
-        self.client_id = CLIENT_ID
-        self.client_secret = CLIENT_SECRET
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_with_basic_auth = refresh_with_basic_auth
+        self.refresh_scope = refresh_scope
 
     def get_device_auth(self) -> JSON:
         res = request(
@@ -75,17 +86,27 @@ class AuthClient:
         return json_data
 
     def refresh_token(self, refresh_token: str) -> JSON:
-        res = request(
-            "POST",
-            f"{self.auth_url}/token",
-            data={
-                "client_id": self.client_id,
-                "refresh_token": refresh_token,
-                "grant_type": "refresh_token",
-                "scope": "r_usr+w_usr+w_sub",
-            },
-            auth=(self.client_id, self.client_secret),
-        )
+        data = {
+            "client_id": self.client_id,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+            "scope": self.refresh_scope,
+        }
+
+        if self.refresh_with_basic_auth:
+            res = request(
+                "POST",
+                f"{self.auth_url}/token",
+                data=data,
+                auth=(self.client_id, self.client_secret),
+            )
+        else:
+            data["client_secret"] = self.client_secret
+            res = request(
+                "POST",
+                f"{self.auth_url}/token",
+                data=data,
+            )
 
         res.raise_for_status()
 

--- a/tiddl/core/auth/models.py
+++ b/tiddl/core/auth/models.py
@@ -43,6 +43,16 @@ class AuthResponseWithRefresh(AuthResponse):
     refresh_token: str
 
 
+class AuthRefreshResponse(AuthResponse):
+    refresh_token: str | None = None
+
+
+class AuthTokenResponse(BaseModel):
+    access_token: str
+    expires_in: int
+    refresh_token: str | None = None
+
+
 class AuthDeviceResponse(BaseModel):
     deviceCode: str
     userCode: str

--- a/tiddl/core/auth/profiles.py
+++ b/tiddl/core/auth/profiles.py
@@ -1,0 +1,123 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import Lock
+from time import time
+from typing import Literal
+
+from tiddl.core.auth.client import (
+    CLIENT_ID,
+    CLIENT_SECRET,
+    AuthClient,
+)
+from tiddl.core.auth.models import AuthTokenResponse
+
+PlaybackProfile = Literal["hires", "atmos"]
+
+
+@dataclass(frozen=True)
+class ClientProfile:
+    client_id: str
+    client_secret: str
+    refresh_with_basic_auth: bool
+
+
+@dataclass(frozen=True)
+class ProfileToken:
+    access_token: str
+    client_id: str
+    expires_at: float
+
+
+# TIDAL exposes different playback capabilities to different client profiles.
+# Both access tokens can be derived from the refresh token created by one login.
+PLAYBACK_SCOPE = "r_usr+w_usr"
+CLIENT_PROFILES: dict[PlaybackProfile, ClientProfile] = {
+    "hires": ClientProfile(
+        client_id="6BDSRdpK9hqEBTgU",
+        client_secret="xeuPmY7nbpZ9IIbLAcQ93shka1VNheUAqN6IcszjTG8=",
+        refresh_with_basic_auth=False,
+    ),
+    "atmos": ClientProfile(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        refresh_with_basic_auth=True,
+    ),
+}
+
+
+def select_playback_profile(
+    atmos_filter: Literal["none", "only", "allow"],
+    atmos_available: bool,
+) -> PlaybackProfile:
+    if atmos_filter == "none":
+        return "hires"
+
+    if atmos_filter == "only" or atmos_available:
+        return "atmos"
+
+    return "hires"
+
+
+class ProfileTokenManager:
+    """Derive and cache capability-specific access tokens from one login."""
+
+    def __init__(
+        self,
+        refresh_token: str,
+        on_refresh_token: Callable[[str], None] | None = None,
+        clock: Callable[[], float] = time,
+        expiry_margin: int = 60,
+        client_factory: Callable[[ClientProfile], AuthClient] | None = None,
+    ) -> None:
+        self._refresh_token = refresh_token
+        self._on_refresh_token = on_refresh_token
+        self._clock = clock
+        self._expiry_margin = expiry_margin
+        self._client_factory = client_factory or self._create_client
+        self._tokens: dict[PlaybackProfile, ProfileToken] = {}
+        self._lock = Lock()
+
+    @staticmethod
+    def _create_client(profile: ClientProfile) -> AuthClient:
+        return AuthClient(
+            client_id=profile.client_id,
+            client_secret=profile.client_secret,
+            refresh_with_basic_auth=profile.refresh_with_basic_auth,
+            refresh_scope=PLAYBACK_SCOPE,
+        )
+
+    def get_token(
+        self, profile_name: PlaybackProfile, force: bool = False
+    ) -> ProfileToken:
+        with self._lock:
+            cached_token = self._tokens.get(profile_name)
+            if (
+                not force
+                and cached_token
+                and cached_token.expires_at > self._clock() + self._expiry_margin
+            ):
+                return cached_token
+
+            profile = CLIENT_PROFILES[profile_name]
+            client = self._client_factory(profile)
+            response = AuthTokenResponse.model_validate(
+                client.refresh_token(self._refresh_token)
+            )
+
+            if response.refresh_token and response.refresh_token != self._refresh_token:
+                self._refresh_token = response.refresh_token
+                if self._on_refresh_token:
+                    self._on_refresh_token(response.refresh_token)
+
+            token = ProfileToken(
+                access_token=response.access_token,
+                client_id=profile.client_id,
+                expires_at=self._clock() + response.expires_in,
+            )
+            self._tokens[profile_name] = token
+            return token
+
+    def replace_refresh_token(self, refresh_token: str) -> None:
+        """Keep the broker synchronized if another API refresh rotates the token."""
+        with self._lock:
+            self._refresh_token = refresh_token


### PR DESCRIPTION
## Problem

TIDAL exposes MAX/Hi-Res stereo and Dolby Atmos through different client profiles.

Tiddl currently uses one client profile for every playback request. This means a profile capable of returning MAX stereo may not return Atmos, while the Atmos-capable profile can return Atmos when stereo was requested or limit the available stereo quality.

The existing Dolby Atmos filter runs after TIDAL has selected the stream. It can skip an unwanted presentation, but it cannot request the alternative one.

## Solution

This PR keeps one TIDAL authorization and one canonical `auth.json`, then derives short-lived access tokens for the Hi-Res and Atmos playback profiles from the same refresh token.

The user still authenticates once. No second login, auth directory, or duplicated user credentials are required.

Playback requests are routed according to the selected audio-mode policy:

- `--dolby-atmos none` uses the Hi-Res profile for stereo playback up to MAX.
- `--dolby-atmos only` uses the Atmos-capable profile.
- `--dolby-atmos allow` prefers Atmos when the track advertises it, otherwise it uses Hi-Res stereo.

For compatibility, the existing option and configuration values remain supported. Internally, they now select the playback presentation instead of merely filtering the stream returned by TIDAL.

Existing-file detection follows the selected presentation, so a Hi-Res FLAC and Dolby Atmos M4A can coexist and are skipped independently.

The derived access tokens are cached in memory and refreshed independently when needed. Each playback request also carries the matching client identity. If TIDAL rotates the refresh token, the replacement is persisted to the existing auth file and reused by both profiles.

Catalog and video requests continue using the existing API session, so the change is limited to track playback selection.

## Result

Confirmed end-to-end using one stored authorization and a track where both MAX quality and Dolby Atmos are available:

- Stereo playback returned a 24-bit `HI_RES_LOSSLESS` FLAC stream.
- Atmos playback returned the Dolby Atmos presentation.
- Both complete downloads succeeded from the same stored authorization.

No authentication schema migration or additional user setup is required.

Related to #333, #359, #395, and #396.
